### PR TITLE
Fix 'yarn changelog'

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "copyright-check": "ts-node src/scripts/copyrightChecker.ts",
     "coverage": "rm -rf coverage && NODE_DEBUG=nyc nyc mocha 'tests/unit/**/*.ts'",
     "create-release": "ts-node src/scripts/createRelease.ts",
-    "changelog": "ts-node src/utils/changelog.ts",
+    "changelog": "ts-node src/scripts/changelog.ts",
     "create-post-release-pull-request": "ts-node src/scripts/createPostReleasePullRequest.ts",
     "create-release-tag": "ts-node src/scripts/createReleaseTag.ts",
     "license-check": "ts-node src/scripts/licenseChecker.ts",

--- a/src/scripts/createRelease.ts
+++ b/src/scripts/createRelease.ts
@@ -142,7 +142,7 @@ export function incrementVersionNumber(originalVersion: string, patchLevel: Patc
 export async function createReleasePR(newBranchName: string, newVersion: string, changes: string[]): Promise<void> {
   await dependencies.simpleGit.push('origin', newBranchName);
 
-  // make a nicely formatted list of changes that will show up properly bulleted in the PR
+  // Make a nicely formatted list of changes that will show up properly bulleted in the PR
   const changeList = getFormattedChangeList(changes);
 
   const title = multiline`

--- a/src/scripts/createRelease.ts
+++ b/src/scripts/createRelease.ts
@@ -83,6 +83,8 @@ export default function createRelease(): Command {
     const originalVersion = packageJson.version;
     dependencies.logger.info(`Current ${packageJsonFilename} version is ${originalVersion}`);
 
+    dependencies.logger.info(`Changelog:\n${getFormattedChangeList(changes)}`);
+
     // Ask user if this is major/minor/patch
     const answer: PatchTypeAnswer = await components.askUserForPatchType();
 
@@ -140,10 +142,13 @@ export function incrementVersionNumber(originalVersion: string, patchLevel: Patc
 export async function createReleasePR(newBranchName: string, newVersion: string, changes: string[]): Promise<void> {
   await dependencies.simpleGit.push('origin', newBranchName);
 
+  // make a nicely formatted list of changes that will show up properly bulleted in the PR
+  const changeList = getFormattedChangeList(changes);
+
   const title = multiline`
     Release ${newVersion}
 
-    ${changes.join('\n')}
+    ${changeList}
   `;
   // Generate PR using github API and put in changelog
   // Could replace this with an HTTP API request and get rid of the unlabelled dependency on Hub
@@ -184,6 +189,13 @@ export async function loadPackageJson(): Promise<PartialPackageJson> {
   } catch (err) {
     throw new ExpectedError(`Unable to parse ${packageJsonFilename}: ${err}`);
   }
+}
+
+/**
+ * Takes in an array of git commit messages and returns a nicely formatted and bulleted list of changes
+ */
+export function getFormattedChangeList(changes: string[]) {
+  return changes.map((change) => `- ${change}`).join('\n');
 }
 
 /**

--- a/tests/unit/scripts/createRelease.ts
+++ b/tests/unit/scripts/createRelease.ts
@@ -56,7 +56,7 @@ describe('scripts/createRelease', () => {
       await createReleasePR(newBranchName, newVersion, changes);
 
       assert.calledOnceWith(push, ['origin', newBranchName]);
-      assert.calledOnceWith(exec, ['hub pull-request -b master -m \"Release 1.0.0\n\nChange 1\nChange 2\"']);
+      assert.calledOnceWith(exec, ['hub pull-request -b master -m \"Release 1.0.0\n\n- Change 1\n- Change 2\"']);
     }));
   });
 


### PR DESCRIPTION
<!--
  Please follow this template unless this is a release PR, which just requires a simple changelog.
  All PRs must be reviewed by at least one senior developer in the Enterprise or Plugins teams.
-->

### Context/purpose

<!-- Who is this for and how does this change help them? -->
Changelog script was moved so `yarn changelog` didn't work.

### Implementation details

<!-- How was this implemented? e.g. overall structure, complexities, caveats -->

### QA instructions

<!-- How can this be tested? Include enough detail for a developer or QA engineer to thoroughly test -->

### Any unrelated changes?

<!-- Anything unrelated included in this PR (remove section if empty) -->
Shows the 'unreleased' changelog to the user before they have to pick a patch level so they can make an informed choice.
Also formatted  the changelog so it'll show up as a nicely formatted and bulleted list.

### PR Checklist

<!-- If this is strictly a documentation change you can replace the following checklist with "Documentation change only" -->

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [ ] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)