### PR TITLE
Throw the original Axios error if we don't understand it

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -7,9 +7,9 @@ import { ApiError } from '../errors';
 import { ApiErrorResponse } from '../types/types';
 
 /** Convert an axios error into the standard Platform Lite API format */
-export const convertError = ({ response }: AxiosError) => {
-  if (response) {
-    const { data, status, statusText } = response;
+export const convertError = (err: AxiosError) => {
+  if (err.response) {
+    const { data, status, statusText } = err.response;
     const { code, message }: ApiErrorResponse = data;
 
     if (message && code) {
@@ -19,7 +19,8 @@ export const convertError = ({ response }: AxiosError) => {
     throw new ApiError(statusText, 'requestError', status);
   }
 
-  throw new ApiError('An unknown error occurred', 'requestError');
+  // Give up and just throw the Axios error
+  throw err;
 };
 
 const request = {

--- a/tests/unit/utils/request.ts
+++ b/tests/unit/utils/request.ts
@@ -44,10 +44,9 @@ describe('utils/request', () => {
       assert.throws(() => convertError(error), errorEquals(expectedError));
     });
 
-    it('Throws an unknown error in the Cover ApiError format', () => {
+    it('Throws an unknown error directly as the original Axios error', () => {
       const error: AxiosError = { ...templateError, response: undefined };
-      const expectedError = new ApiError('An unknown error occurred', 'requestError');
-      assert.throws(() => convertError(error), errorEquals(expectedError));
+      assert.throws(() => convertError(error), errorEquals(error));
     });
   });
 


### PR DESCRIPTION
### Context/purpose

When an error occurs in Axios, all the client gets back is `'An unknown error occurred', 'requestError'`, which doesn't help to diagnose the problem at all. We've been getting this if we had e.g. the wrong URL for the application server, or many other things.

We spent 2-3 hours for 2 of us trying to figure out why this was happening on one machine but not on another. Eventually it turned out that Axios was refusing to send the request because the body was too big (it was a fairly large Jar file). With this fix in place, straight away you see "Request body larger than maxBodyLength limit" as the error message.

### Implementation details

Just throw the Axios error, don't eat it. This means users can do something with the result.

### QA instructions

Using the gitlab plugin, point your api server to the wrong URL. Check you have a reasonable response.

### PR Checklist

- [X] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [X] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [ ] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
