### PR TITLE
Relax lifecycle requirements for Analysis methods [TG-8146]

### DIFF
--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -63,11 +63,11 @@ export default class Analysis {
   }
 
   /** Check if analysis is running */
-  private checkInProgress(): void {
-    if (!this.isInProgress()) {
+  private checkStarted(): void {
+    if (this.isNotStarted()) {
       throw new AnalysisError(
-        `Analysis is not in progress (status: ${this.status}).`,
-        AnalysisErrorCodes.NOT_IN_PROGRESS,
+        'Analysis has not been started.',
+        AnalysisErrorCodes.NOT_STARTED,
       );
     }
     if (!this.analysisId) {
@@ -189,7 +189,7 @@ export default class Analysis {
 
   /** Cancel the analysis */
   public async cancel(): Promise<AnalysisCancelApiResponse> {
-    this.checkInProgress();
+    this.checkStarted();
     const response = await components.cancelAnalysis(this.apiUrl, this.analysisId!, this.bindingsOptions);
     this.updateStatus(response.status);
     return response;
@@ -197,7 +197,7 @@ export default class Analysis {
 
   /** Get the analysis's status */
   public async getStatus(): Promise<AnalysisStatusApiResponse> {
-    this.checkInProgress();
+    this.checkStarted();
     const response = await components.getAnalysisStatus(this.apiUrl, this.analysisId!, this.bindingsOptions);
     this.updateStatus(response);
     return response;
@@ -205,7 +205,7 @@ export default class Analysis {
 
   /** Get the analysis's results */
   public async getResults(useCursor: boolean = true): Promise<AnalysisResultsApiResponse> {
-    this.checkInProgress();
+    this.checkStarted();
     const response = await components.getAnalysisResults(
       this.apiUrl,
       this.analysisId!,

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -10,7 +10,7 @@ import {
   startAnalysis,
 } from './bindings';
 import { getFileNameForResult, groupResults } from './combiner';
-import { AnalysisError, AnalysisErrorCodes } from './errors';
+import { AnalysisError, AnalysisErrorCode } from './errors';
 import {
   AnalysisCancelApiResponse,
   AnalysisFiles,
@@ -20,8 +20,8 @@ import {
   AnalysisResultsApiResponse,
   AnalysisSettings,
   AnalysisStartApiResponse,
+  AnalysisStatus,
   AnalysisStatusApiResponse,
-  AnalysisStatuses,
   ApiErrorResponse,
   ApiVersionApiResponse,
   BindingsOptions,
@@ -47,7 +47,7 @@ export default class Analysis {
   public bindingsOptions: BindingsOptions;
   public analysisId?: string;
   public settings?: AnalysisSettings;
-  public status?: AnalysisStatuses;
+  public status?: AnalysisStatus;
   public progress?: AnalysisProgress;
   public error?: ApiErrorResponse;
   public phases?: AnalysisPhases;
@@ -67,11 +67,11 @@ export default class Analysis {
     if (this.isNotStarted()) {
       throw new AnalysisError(
         'Analysis has not been started.',
-        AnalysisErrorCodes.NOT_STARTED,
+        AnalysisErrorCode.NOT_STARTED,
       );
     }
     if (!this.analysisId) {
-      throw new AnalysisError('Analysis is in progress but the analysis id is not set.', AnalysisErrorCodes.NO_ID);
+      throw new AnalysisError('Analysis is in progress but the analysis id is not set.', AnalysisErrorCode.NO_ID);
     }
   }
 
@@ -80,14 +80,14 @@ export default class Analysis {
     if (this.isStarted()) {
       throw new AnalysisError(
         `Analysis has already started (status: ${this.status}).`,
-        AnalysisErrorCodes.ALREADY_STARTED,
+        AnalysisErrorCode.ALREADY_STARTED,
       );
     }
   }
 
   /** Update status related properties */
   private updateStatus(status: AnalysisStatusApiResponse): void {
-    this.status = AnalysisStatuses[status.status];
+    this.status = AnalysisStatus[status.status];
     this.progress = status.progress;
     this.error = status.message;
   }
@@ -141,7 +141,7 @@ export default class Analysis {
         if (this.isErrored()) {
           throw new AnalysisError(
             'Analysis ended with ERRORED status.',
-            AnalysisErrorCodes.RUN_ERRORED,
+            AnalysisErrorCode.RUN_ERRORED,
           );
         }
       }
@@ -183,7 +183,7 @@ export default class Analysis {
     this.settings = settings;
     this.analysisId = response.id;
     this.phases = response.phases;
-    this.status = AnalysisStatuses.QUEUED;
+    this.status = AnalysisStatus.QUEUED;
     return response;
   }
 
@@ -232,27 +232,27 @@ export default class Analysis {
 
   /** Check if status is queued */
   public isQueued(): boolean {
-    return this.status === AnalysisStatuses.QUEUED;
+    return this.status === AnalysisStatus.QUEUED;
   }
 
   /** Check if status is running */
   public isRunning(): boolean {
-    return this.status === AnalysisStatuses.RUNNING;
+    return this.status === AnalysisStatus.RUNNING;
   }
 
   /** Check if status is completed */
   public isCompleted(): boolean {
-    return this.status === AnalysisStatuses.COMPLETED;
+    return this.status === AnalysisStatus.COMPLETED;
   }
 
   /** Check if status is errored */
   public isErrored(): boolean {
-    return this.status === AnalysisStatuses.ERRORED;
+    return this.status === AnalysisStatus.ERRORED;
   }
 
   /** Check if status is canceled */
   public isCanceled(): boolean {
-    return this.status === AnalysisStatuses.CANCELED;
+    return this.status === AnalysisStatus.CANCELED;
   }
 
   /** Check if status indicates that the analysis has started */
@@ -266,9 +266,9 @@ export default class Analysis {
       return false;
     }
     const endedStatuses = new Set([
-      AnalysisStatuses.COMPLETED,
-      AnalysisStatuses.ERRORED,
-      AnalysisStatuses.CANCELED,
+      AnalysisStatus.COMPLETED,
+      AnalysisStatus.ERRORED,
+      AnalysisStatus.CANCELED,
     ]);
     return endedStatuses.has(this.status);
   }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -4,7 +4,7 @@ import { AxiosRequestConfig } from 'axios';
 import * as FormData from 'form-data';
 import { Agent } from 'https';
 
-import { BindingsError, BindingsErrorCodes } from './errors';
+import { BindingsError, BindingsErrorCode } from './errors';
 import {
   AnalysisCancelApiResponse,
   AnalysisFiles,
@@ -54,7 +54,7 @@ export async function startAnalysis(
   options?: BindingsOptions,
 ): Promise<AnalysisStartApiResponse> {
   if (!build) {
-    throw new BindingsError('The required `build` JAR file was not supplied', BindingsErrorCodes.BUILD_MISSING);
+    throw new BindingsError('The required `build` JAR file was not supplied', BindingsErrorCode.BUILD_MISSING);
   }
 
   const getOptions = (filename: string, type: 'java-archive' | 'json') => ({
@@ -68,7 +68,7 @@ export async function startAnalysis(
   try {
     formData.append('settings', JSON.stringify(settings), getOptions('settings.json', 'json'));
   } catch (error) {
-    throw new BindingsError(`The settings JSON was not valid:\n${error}`, BindingsErrorCodes.SETTINGS_INVALID);
+    throw new BindingsError(`The settings JSON was not valid:\n${error}`, BindingsErrorCode.SETTINGS_INVALID);
   }
 
   if (baseBuild) {

--- a/src/combiner.ts
+++ b/src/combiner.ts
@@ -3,7 +3,7 @@
 import { genTestClass, ITestData, mergeTests } from '@diffblue/java-combiner';
 import { groupBy, isString } from 'lodash';
 
-import { CombinerError, CombinerErrorCodes } from './errors';
+import { CombinerError, CombinerErrorCode } from './errors';
 import { AnalysisResult } from './types/types';
 
 export const dependencies = {
@@ -37,7 +37,7 @@ function parseClassNameFromFunctionName(functionName: string): string {
   const classNameRegexp = /([^.:]+)[.][^.]*$/;
   const classNameMatch = functionName.match(classNameRegexp);
   if (!classNameMatch) {
-    throw new CombinerError(`Can't find classname in ${functionName}`, CombinerErrorCodes.NO_CLASS_NAME);
+    throw new CombinerError(`Can't find classname in ${functionName}`, CombinerErrorCode.NO_CLASS_NAME);
   }
   return classNameMatch[1].replace(/\$/g, '_');
 }
@@ -47,19 +47,19 @@ function checkResults(results: AnalysisResult[]): void {
   if (!results) {
     throw new CombinerError(
       'Missing required parameter "results"',
-      CombinerErrorCodes.RESULTS_MISSING,
+      CombinerErrorCode.RESULTS_MISSING,
     );
   }
   if (!Array.isArray(results)) {
     throw new CombinerError(
       '"results" must be an array',
-      CombinerErrorCodes.RESULTS_TYPE,
+      CombinerErrorCode.RESULTS_TYPE,
     );
   }
   if (!results.length) {
     throw new CombinerError(
       '"results" must not be empty',
-      CombinerErrorCodes.RESULTS_EMPTY,
+      CombinerErrorCode.RESULTS_EMPTY,
     );
   }
   const sourceFilePaths = new Set();
@@ -73,19 +73,19 @@ function checkResults(results: AnalysisResult[]): void {
   if (sourceFilePaths.size !== 1) {
     throw new CombinerError(
       'All "results" must have the same "sourceFilePath"',
-      CombinerErrorCodes.SOURCE_FILE_PATH_DIFFERS,
+      CombinerErrorCode.SOURCE_FILE_PATH_DIFFERS,
     );
   }
   if (classNames.size !== 1) {
     throw new CombinerError(
       'All "results" must have a "testedFunction" that produces the same "className" when parsed',
-      CombinerErrorCodes.CLASS_NAME_DIFFERS,
+      CombinerErrorCode.CLASS_NAME_DIFFERS,
     );
   }
   if (packageNames.size !== 1) {
     throw new CombinerError(
       'All "results" must have a "testedFunction" that produces the same "packageName" when parsed',
-      CombinerErrorCodes.PACKAGE_NAME_DIFFERS,
+      CombinerErrorCode.PACKAGE_NAME_DIFFERS,
     );
   }
 }
@@ -95,13 +95,13 @@ function checkExistingClass(existingClass: string): void {
   if (!existingClass) {
     throw new CombinerError(
       'Missing required parameter "existingClass"',
-      CombinerErrorCodes.EXISTING_CLASS_MISSING,
+      CombinerErrorCode.EXISTING_CLASS_MISSING,
     );
   }
   if (!isString(existingClass)) {
     throw new CombinerError(
       '"existingClass" must be a string',
-      CombinerErrorCodes.EXISTING_CLASS_TYPE,
+      CombinerErrorCode.EXISTING_CLASS_TYPE,
     );
   }
 }
@@ -131,7 +131,7 @@ export function generateTestClass(results: AnalysisResult[]): string {
   try {
     return dependencies.genTestClass(testData, className, testName, packageName);
   } catch (error) {
-    throw new CombinerError(`Unexpected error generating test class:\n${error}`, CombinerErrorCodes.GENERATE_ERROR);
+    throw new CombinerError(`Unexpected error generating test class:\n${error}`, CombinerErrorCode.GENERATE_ERROR);
   }
 }
 
@@ -143,7 +143,7 @@ export async function mergeIntoTestClass(existingClass: string, results: Analysi
   try {
     return await dependencies.mergeTests(existingClass, testData);
   } catch (error) {
-    throw new CombinerError(`Unexpected error merging tests:\n${error}`, CombinerErrorCodes.MERGE_ERROR);
+    throw new CombinerError(`Unexpected error merging tests:\n${error}`, CombinerErrorCode.MERGE_ERROR);
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -104,7 +104,7 @@ export class WriterError extends CoverClientError {
 
 /** Error codes used by AnalysisError */
 export enum AnalysisErrorCodes {
-  NOT_IN_PROGRESS = 'NOT_IN_PROGRESS',
+  NOT_STARTED = 'NOT_STARTED',
   ALREADY_STARTED = 'ALREADY_STARTED',
   NO_ID = 'NO_ID',
   RUN_ERRORED = 'RUN_ERRORED',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,7 +34,7 @@ export class ApiError extends CoverClientError {
 }
 
 /** Error codes used by BindingsError */
-export enum BindingsErrorCodes {
+export enum BindingsErrorCode {
   BUILD_MISSING = 'BUILD_MISSING',
   SETTINGS_INVALID = 'SETTINGS_INVALID',
 }
@@ -43,9 +43,9 @@ export enum BindingsErrorCodes {
 export class BindingsError extends CoverClientError {
 
   public message: string;
-  public code: BindingsErrorCodes;
+  public code: BindingsErrorCode;
 
-  public constructor(message: string, code: BindingsErrorCodes) {
+  public constructor(message: string, code: BindingsErrorCode) {
     super(message);
     this.code = code;
     this.name = `BindingsError ${this.code}`;
@@ -54,7 +54,7 @@ export class BindingsError extends CoverClientError {
 }
 
 /** Error codes used by CombinerError */
-export enum CombinerErrorCodes {
+export enum CombinerErrorCode {
   RESULTS_MISSING = 'RESULTS_MISSING',
   RESULTS_EMPTY = 'RESULTS_EMPTY',
   RESULTS_TYPE = 'RESULTS_TYPE',
@@ -72,9 +72,9 @@ export enum CombinerErrorCodes {
 export class CombinerError extends CoverClientError {
 
   public message: string;
-  public code: CombinerErrorCodes;
+  public code: CombinerErrorCode;
 
-  public constructor(message: string, code: CombinerErrorCodes) {
+  public constructor(message: string, code: CombinerErrorCode) {
     super(message);
     this.code = code;
     this.name = `CombinerError ${this.code}`;
@@ -83,7 +83,7 @@ export class CombinerError extends CoverClientError {
 }
 
 /** Error codes used by WriterError */
-export enum WriterErrorCodes {
+export enum WriterErrorCode {
   DIR_FAILED = 'DIR_FAILED',
   WRITE_FAILED = 'WRITE_FAILED',
 }
@@ -92,9 +92,9 @@ export enum WriterErrorCodes {
 export class WriterError extends CoverClientError {
 
   public message: string;
-  public code: WriterErrorCodes;
+  public code: WriterErrorCode;
 
-  public constructor(message: string, code: WriterErrorCodes) {
+  public constructor(message: string, code: WriterErrorCode) {
     super(message);
     this.code = code;
     this.name = `WriterError ${this.code}`;
@@ -103,7 +103,7 @@ export class WriterError extends CoverClientError {
 }
 
 /** Error codes used by AnalysisError */
-export enum AnalysisErrorCodes {
+export enum AnalysisErrorCode {
   NOT_STARTED = 'NOT_STARTED',
   ALREADY_STARTED = 'ALREADY_STARTED',
   NO_ID = 'NO_ID',
@@ -114,9 +114,9 @@ export enum AnalysisErrorCodes {
 export class AnalysisError extends CoverClientError {
 
   public message: string;
-  public code: AnalysisErrorCodes;
+  public code: AnalysisErrorCode;
 
-  public constructor(message: string, code: AnalysisErrorCodes) {
+  public constructor(message: string, code: AnalysisErrorCode) {
     super(message);
     this.code = code;
     this.name = `AnalysisError ${this.code}`;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 /** Possible analysis statuses */
-export enum AnalysisStatuses {
+export enum AnalysisStatus {
   QUEUED = 'QUEUED',
   RUNNING = 'RUNNING',
   CANCELED = 'CANCELED',
@@ -88,7 +88,7 @@ export interface AnalysisSettings {
 
 /** Status object returned by the API */
 export interface AnalysisStatusApiResponse {
-  status: AnalysisStatuses;
+  status: AnalysisStatus;
   progress: AnalysisProgress;
   message?: ApiErrorResponse;
 }

--- a/src/writeTests.ts
+++ b/src/writeTests.ts
@@ -13,7 +13,7 @@ import {
   groupResults,
   mergeIntoTestClass,
 } from './combiner';
-import { WriterError, WriterErrorCodes } from './errors';
+import { WriterError, WriterErrorCode } from './errors';
 import { AnalysisResult, WriteTestsOptions } from './types/types';
 
 export const dependencies = {
@@ -47,7 +47,7 @@ export default async function writeTests(
   } catch (error) {
     throw new WriterError(
       `Could not create the directory ${directoryPath}:\n${error}.`,
-      WriterErrorCodes.DIR_FAILED,
+      WriterErrorCode.DIR_FAILED,
     );
   }
   const groupedResults = groupResults(results);
@@ -85,7 +85,7 @@ export default async function writeTests(
     });
     throw new WriterError(
       `Test writing failed for some results:\n${errorList.join('\n')}.`,
-      WriterErrorCodes.WRITE_FAILED,
+      WriterErrorCode.WRITE_FAILED,
     );
   }
   return successPaths.sort();

--- a/tests/unit/analysis.ts
+++ b/tests/unit/analysis.ts
@@ -6,8 +6,8 @@ import assert from '../../src/utils/assertExtra';
 import sinonTestFactory from '../../src/utils/sinonTest';
 
 import Analysis, { components } from '../../src/analysis';
-import { AnalysisError, AnalysisErrorCodes } from '../../src/errors';
-import { AnalysisStatuses } from '../../src/types/types';
+import { AnalysisError, AnalysisErrorCode } from '../../src/errors';
+import { AnalysisStatus } from '../../src/types/types';
 
 const sinonTest = sinonTestFactory();
 const sinonTestWithTimers = sinonTestFactory({ useFakeTimers: false });
@@ -75,7 +75,7 @@ describe('analysis', () => {
 
     describe('run', () => {
       const startResponse = { id: analysisId, phases: {}};
-      const responseStatus = { status: AnalysisStatuses.CANCELED, progress: { completed: 10, total: 20 }};
+      const responseStatus = { status: AnalysisStatus.CANCELED, progress: { completed: 10, total: 20 }};
       const resultsResponse = {
         status: responseStatus,
         cursor: 12345,
@@ -91,7 +91,7 @@ describe('analysis', () => {
         const changes = {
           analysisId: analysisId,
           settings: settings,
-          status: AnalysisStatuses.CANCELED,
+          status: AnalysisStatus.CANCELED,
           phases: {},
           pollDelay: undefined,
           cursor: resultsResponse.cursor,
@@ -116,7 +116,7 @@ describe('analysis', () => {
         const changes = {
           analysisId: analysisId,
           settings: settings,
-          status: AnalysisStatuses.CANCELED,
+          status: AnalysisStatus.CANCELED,
           phases: {},
           pollDelay: undefined,
           cursor: resultsResponse.cursor,
@@ -214,7 +214,7 @@ describe('analysis', () => {
 
       it('Rejects if analysis errors, and does not write test files', sinonTestWithTimers(async (sinon) => {
         const startAnalysis = sinon.stub(components, 'startAnalysis').resolves(startResponse);
-        const responseStatus = { status: AnalysisStatuses.ERRORED, progress: { completed: 10, total: 20 }};
+        const responseStatus = { status: AnalysisStatus.ERRORED, progress: { completed: 10, total: 20 }};
         const response = {
           ...resultsResponse,
           status: responseStatus,
@@ -226,7 +226,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.run(files, settings, options),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.RUN_ERRORED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.RUN_ERRORED;
           },
         );
         assert.calledOnceWith(startAnalysis, [apiUrl, files, {}, {}]);
@@ -237,7 +237,7 @@ describe('analysis', () => {
       it('Calling forceStop stops polling (after polling occurs)', sinonTestWithTimers(async (sinon) => {
         const startAnalysis = sinon.stub(components, 'startAnalysis').resolves(startResponse);
         const getAnalysisResults = sinon.stub(components, 'getAnalysisResults');
-        const responseStatus = { status: AnalysisStatuses.RUNNING, progress: { completed: 10, total: 20 }};
+        const responseStatus = { status: AnalysisStatus.RUNNING, progress: { completed: 10, total: 20 }};
         const response = {
           ...resultsResponse,
           status: responseStatus,
@@ -249,14 +249,14 @@ describe('analysis', () => {
         setTimeout(() => analysis.forceStop(), 10);
         const returnValue = await analysis.run(files, settings, { pollingInterval: 0.0001 });
         assert.deepStrictEqual(returnValue, resultsResponse.results);
-        assert.strictEqual(analysis.status, AnalysisStatuses.RUNNING);
+        assert.strictEqual(analysis.status, AnalysisStatus.RUNNING);
         assert.calledOnceWith(startAnalysis, [apiUrl, files, {}, {}]);
         sinon.assert.calledWith(getAnalysisResults, apiUrl, analysisId, undefined, {});
       }));
 
       it('Calling forceStop stops polling (before polling occurs)', sinonTestWithTimers(async (sinon) => {
         const startAnalysis = sinon.stub(components, 'startAnalysis').resolves(startResponse);
-        const responseStatus = { status: AnalysisStatuses.RUNNING, progress: { completed: 10, total: 20 }};
+        const responseStatus = { status: AnalysisStatus.RUNNING, progress: { completed: 10, total: 20 }};
         const response = {
           ...resultsResponse,
           status: responseStatus,
@@ -267,7 +267,7 @@ describe('analysis', () => {
         setImmediate(() => analysis.forceStop());
         const returnValue = await analysis.run(files, settings, { pollingInterval: 10 });
         assert.deepStrictEqual(returnValue, []);
-        assert.strictEqual(analysis.status, AnalysisStatuses.QUEUED);
+        assert.strictEqual(analysis.status, AnalysisStatus.QUEUED);
         assert.calledOnceWith(startAnalysis, [apiUrl, files, {}, {}]);
         assert.notCalled(getAnalysisResults);
       }));
@@ -316,7 +316,7 @@ describe('analysis', () => {
         const changes = {
           analysisId: returnValue.id,
           settings: settings,
-          status: AnalysisStatuses.QUEUED,
+          status: AnalysisStatus.QUEUED,
           phases: returnValue.phases,
         };
         assert.deepStrictEqual(returnValue, startResponse);
@@ -333,7 +333,7 @@ describe('analysis', () => {
         const changes = {
           analysisId: returnValue.id,
           settings: settings,
-          status: AnalysisStatuses.QUEUED,
+          status: AnalysisStatus.QUEUED,
           phases: returnValue.phases,
         };
         assert.calledOnceWith(startAnalysis, [apiUrl, allFiles, settings, {}]);
@@ -360,11 +360,11 @@ describe('analysis', () => {
         sinon.stub(components, 'startAnalysis').resolves(startResponse);
         const analysis = new Analysis(apiUrl);
         await analysis.start(files, settings);
-        assert.strictEqual(analysis.status, AnalysisStatuses.QUEUED);
+        assert.strictEqual(analysis.status, AnalysisStatus.QUEUED);
         await assert.rejects(
           async () => analysis.start(files, settings),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.ALREADY_STARTED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.ALREADY_STARTED;
           },
         );
       }));
@@ -372,18 +372,18 @@ describe('analysis', () => {
       it('Fails to start an analysis, if already canceled', sinonTest(async (sinon) => {
         sinon.stub(components, 'startAnalysis').resolves(startResponse);
         const cancelAnalysis = sinon.stub(components, 'cancelAnalysis');
-        const cancelStatus = { status: AnalysisStatuses.CANCELED, progress: { completed: 10, total: 20 }};
+        const cancelStatus = { status: AnalysisStatus.CANCELED, progress: { completed: 10, total: 20 }};
         const cancelMessage = 'Analysis cancelled successfully';
         const cancelResponse = { message: cancelMessage, status: cancelStatus };
         cancelAnalysis.resolves(cancelResponse);
         const analysis = new Analysis(apiUrl);
         await analysis.start(files, settings);
         await analysis.cancel();
-        assert.strictEqual(analysis.status, AnalysisStatuses.CANCELED);
+        assert.strictEqual(analysis.status, AnalysisStatus.CANCELED);
         await assert.rejects(
           async () => analysis.start(files, settings),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.ALREADY_STARTED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.ALREADY_STARTED;
           },
         );
       }));
@@ -391,7 +391,7 @@ describe('analysis', () => {
 
     describe('cancel', () => {
       const startResponse = { id: analysisId, phases: {}};
-      const cancelStatus = { status: AnalysisStatuses.CANCELED, progress: { completed: 10, total: 20 }};
+      const cancelStatus = { status: AnalysisStatus.CANCELED, progress: { completed: 10, total: 20 }};
       const cancelMessage = 'Analysis cancelled successfully';
       const cancelResponse = { message: cancelMessage, status: cancelStatus };
 
@@ -426,7 +426,7 @@ describe('analysis', () => {
         const cancelAnalysis = sinon.stub(components, 'cancelAnalysis').resolves(cancelResponse);
         const analysis = new Analysis(apiUrl);
         await analysis.start(files, settings);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         const returnValue = await analysis.cancel();
         assert.deepStrictEqual(returnValue, cancelResponse);
         assert.calledOnceWith(cancelAnalysis, [apiUrl, analysisId, {}]);
@@ -449,7 +449,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.cancel(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NOT_STARTED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NOT_STARTED;
           },
         );
       }));
@@ -462,7 +462,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.cancel(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NO_ID;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NO_ID;
           },
         );
       }));
@@ -470,7 +470,7 @@ describe('analysis', () => {
 
     describe('getStatus', () => {
       const startResponse = { id: analysisId, phases: {}};
-      const statusResponse = { status: AnalysisStatuses.COMPLETED, progress: { completed: 100, total: 100 }};
+      const statusResponse = { status: AnalysisStatus.COMPLETED, progress: { completed: 100, total: 100 }};
 
       it('Can get the status of an analysis', sinonTest(async (sinon) => {
         sinon.stub(components, 'startAnalysis').resolves(startResponse);
@@ -493,7 +493,7 @@ describe('analysis', () => {
         sinon.stub(components, 'startAnalysis').resolves(startResponse);
         const response = {
           ...statusResponse,
-          status: AnalysisStatuses.ERRORED,
+          status: AnalysisStatus.ERRORED,
           message: { code: 'analysis-not-found', message: 'Analysis not found' },
         };
         const getAnalysisStatus = sinon.stub(components, 'getAnalysisStatus').resolves(response);
@@ -525,7 +525,7 @@ describe('analysis', () => {
         const getAnalysisStatus = sinon.stub(components, 'getAnalysisStatus').resolves(statusResponse);
         const analysis = new Analysis(apiUrl);
         await analysis.start(files, settings);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         const returnValue = await analysis.getStatus();
         assert.deepStrictEqual(returnValue, statusResponse);
         assert.calledOnceWith(getAnalysisStatus, [apiUrl, analysisId, {}]);
@@ -548,7 +548,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.getStatus(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NOT_STARTED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NOT_STARTED;
           },
         );
       }));
@@ -562,7 +562,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.getStatus(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NO_ID;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NO_ID;
           },
         );
       }));
@@ -570,7 +570,7 @@ describe('analysis', () => {
 
     describe('getResults', () => {
       const startResponse = { id: analysisId, phases: {}};
-      const responseStatus = { status: AnalysisStatuses.RUNNING, progress: { completed: 10, total: 20 }};
+      const responseStatus = { status: AnalysisStatus.RUNNING, progress: { completed: 10, total: 20 }};
       const resultsResponse = {
         status: responseStatus,
         cursor: 12345,
@@ -659,7 +659,7 @@ describe('analysis', () => {
         const getAnalysisResults = sinon.stub(components, 'getAnalysisResults').resolves(resultsResponse);
         const analysis = new Analysis(apiUrl);
         await analysis.start(files, settings);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         const returnValue = await analysis.getResults(false);
         assert.deepStrictEqual(returnValue, resultsResponse);
         assert.calledOnceWith(getAnalysisResults, [apiUrl, analysisId, undefined, {}]);
@@ -682,7 +682,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.getResults(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NOT_STARTED;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NOT_STARTED;
           },
         );
       }));
@@ -695,7 +695,7 @@ describe('analysis', () => {
         await assert.rejects(
           async () => analysis.getResults(),
           (err: Error) => {
-            return (err instanceof AnalysisError) && err.code === AnalysisErrorCodes.NO_ID;
+            return (err instanceof AnalysisError) && err.code === AnalysisErrorCode.NO_ID;
           },
         );
       }));
@@ -709,74 +709,74 @@ describe('analysis', () => {
 
       it('Knows if its status is not not started', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isNotStarted(), false);
       });
 
       it('Knows if its status is queued', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.QUEUED;
+        analysis.status = AnalysisStatus.QUEUED;
         assert.strictEqual(analysis.isQueued(), true);
       });
 
       it('Knows if its status is not queued', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         assert.strictEqual(analysis.isQueued(), false);
       });
 
 
       it('Knows if its status is running', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isRunning(), true);
       });
 
       it('Knows if its status is not running', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         assert.strictEqual(analysis.isRunning(), false);
       });
 
       it('Knows if its status is canceled', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.CANCELED;
+        analysis.status = AnalysisStatus.CANCELED;
         assert.strictEqual(analysis.isCanceled(), true);
       });
 
       it('Knows if its status is not canceled', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.ERRORED;
+        analysis.status = AnalysisStatus.ERRORED;
         assert.strictEqual(analysis.isCanceled(), false);
       });
 
       it('Knows if its status is errored', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.ERRORED;
+        analysis.status = AnalysisStatus.ERRORED;
         assert.strictEqual(analysis.isErrored(), true);
       });
 
       it('Knows if its status is not errored', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         assert.strictEqual(analysis.isErrored(), false);
       });
 
       it('Knows if its status is completed', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.COMPLETED;
+        analysis.status = AnalysisStatus.COMPLETED;
         assert.strictEqual(analysis.isCompleted(), true);
       });
 
       it('Knows if its status is not completed', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isCompleted(), false);
       });
 
       it('Knows if it has started', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isStarted(), true);
       });
 
@@ -787,13 +787,13 @@ describe('analysis', () => {
 
       it('Knows if it has ended', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.CANCELED;
+        analysis.status = AnalysisStatus.CANCELED;
         assert.strictEqual(analysis.isEnded(), true);
       });
 
       it('Knows if it has not ended', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isEnded(), false);
       });
 
@@ -804,16 +804,16 @@ describe('analysis', () => {
 
       it('Knows if it is in progress', () => {
         const analysis = new Analysis(apiUrl);
-        analysis.status = AnalysisStatuses.QUEUED;
+        analysis.status = AnalysisStatus.QUEUED;
         assert.strictEqual(analysis.isInProgress(), true);
-        analysis.status = AnalysisStatuses.RUNNING;
+        analysis.status = AnalysisStatus.RUNNING;
         assert.strictEqual(analysis.isInProgress(), true);
       });
 
       it('Knows if it is not in progress', () => {
         const analysis = new Analysis(apiUrl);
         assert.strictEqual(analysis.isInProgress(), false);
-        analysis.status = AnalysisStatuses.ERRORED;
+        analysis.status = AnalysisStatus.ERRORED;
         assert.strictEqual(analysis.isInProgress(), false);
       });
     });

--- a/tests/unit/bindings.ts
+++ b/tests/unit/bindings.ts
@@ -9,7 +9,7 @@ import {
   getApiVersion,
   startAnalysis,
 } from '../../src/bindings';
-import { BindingsError, BindingsErrorCodes } from '../../src/errors';
+import { BindingsError, BindingsErrorCode } from '../../src/errors';
 import assert from '../../src/utils/assertExtra';
 import sinonTestFactory from '../../src/utils/sinonTest';
 
@@ -123,7 +123,7 @@ describe('api/bindings', () => {
       await assert.rejectsWith(
         // tslint:disable-next-line:no-any
         startAnalysis(api, { build: undefined } as any, settings),
-        new BindingsError('The required `build` JAR file was not supplied', BindingsErrorCodes.BUILD_MISSING),
+        new BindingsError('The required `build` JAR file was not supplied', BindingsErrorCode.BUILD_MISSING),
       );
     }));
 
@@ -132,7 +132,7 @@ describe('api/bindings', () => {
       const obj: { a?: Object } = {};
       obj.a = { b: obj };
 
-      const expectedError = new RegExp(BindingsErrorCodes.SETTINGS_INVALID);
+      const expectedError = new RegExp(BindingsErrorCode.SETTINGS_INVALID);
 
       await assert.rejectsWith(
         startAnalysis(api, { build: build }, obj as any), expectedError, // tslint:disable-line:no-any

--- a/tests/unit/combiner.ts
+++ b/tests/unit/combiner.ts
@@ -8,7 +8,7 @@ import {
   groupResults,
   mergeIntoTestClass,
 } from '../../src/combiner';
-import { CombinerError, CombinerErrorCodes } from '../../src/errors';
+import { CombinerError, CombinerErrorCode } from '../../src/errors';
 import assert from '../../src/utils/assertExtra';
 import sinonTestFactory from '../../src/utils/sinonTest';
 
@@ -65,7 +65,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([sampleResult, otherResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.SOURCE_FILE_PATH_DIFFERS;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.SOURCE_FILE_PATH_DIFFERS;
         },
       );
     });
@@ -78,7 +78,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([sampleResult, otherResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.CLASS_NAME_DIFFERS;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.CLASS_NAME_DIFFERS;
         },
       );
     });
@@ -91,7 +91,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([sampleResult, otherResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.PACKAGE_NAME_DIFFERS;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.PACKAGE_NAME_DIFFERS;
         },
       );
     });
@@ -104,7 +104,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([badResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.NO_CLASS_NAME;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.NO_CLASS_NAME;
         },
       );
     });
@@ -113,7 +113,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass(undefined as any),  // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_MISSING;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_MISSING;
         },
       );
     });
@@ -122,7 +122,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass(new Set([sampleResult]) as any),  // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_TYPE;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_TYPE;
         },
       );
     });
@@ -131,7 +131,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([] as any),  // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_EMPTY;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_EMPTY;
         },
       );
     });
@@ -142,7 +142,7 @@ describe('combiner', () => {
       assert.throws(
         () => generateTestClass([sampleResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.GENERATE_ERROR;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.GENERATE_ERROR;
         },
       );
     }));
@@ -163,7 +163,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass('', [sampleResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.EXISTING_CLASS_MISSING;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.EXISTING_CLASS_MISSING;
         },
       );
     });
@@ -172,7 +172,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass(Buffer.alloc(0) as any, [sampleResult]), // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.EXISTING_CLASS_TYPE;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.EXISTING_CLASS_TYPE;
         },
       );
     });
@@ -184,7 +184,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass(existingTestClass, [sampleResult]),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.MERGE_ERROR;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.MERGE_ERROR;
         },
       );
     }));
@@ -194,7 +194,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass(existingTestClass, undefined as any),  // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_MISSING;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_MISSING;
         },
       );
     });
@@ -207,7 +207,7 @@ describe('combiner', () => {
           new Set([sampleResult]) as any,  // tslint:disable-line:no-any
         ),
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_TYPE;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_TYPE;
         },
       );
     });
@@ -217,7 +217,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass(existingTestClass, [] as any),  // tslint:disable-line:no-any
         (err: Error) => {
-          return (err instanceof CombinerError) && err.code === CombinerErrorCodes.RESULTS_EMPTY;
+          return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_EMPTY;
         },
       );
     });

--- a/tests/unit/writeTests.ts
+++ b/tests/unit/writeTests.ts
@@ -6,7 +6,7 @@ import assert from '../../src/utils/assertExtra';
 import sinonTestFactory from '../../src/utils/sinonTest';
 import TestError from '../../src/utils/TestError';
 
-import { WriterError, WriterErrorCodes } from '../../src/errors';
+import { WriterError, WriterErrorCode } from '../../src/errors';
 import writeTests, { components, dependencies } from '../../src/writeTests';
 
 const sinonTest = sinonTestFactory();
@@ -96,7 +96,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(readFileError.message)
           );
@@ -121,7 +121,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(generateTestClassError.message)
           );
@@ -147,7 +147,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(mergeIntoTestClassError.message)
           );
@@ -173,7 +173,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(writeFileError.message)
           );
@@ -200,7 +200,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(writeFileError.message)
           );
@@ -226,7 +226,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.DIR_FAILED
+            && err.code === WriterErrorCode.DIR_FAILED
           );
         },
       );
@@ -250,7 +250,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
             && err.message.includes(getFileNameForResultError.message)
           );
@@ -276,7 +276,7 @@ describe('writer', () => {
         (err: Error) => {
           return (
             (err instanceof WriterError)
-            && err.code === WriterErrorCodes.WRITE_FAILED
+            && err.code === WriterErrorCode.WRITE_FAILED
             && err.message.includes(`sourceFilePath: ${otherResult.sourceFilePath}`)
             && err.message.includes(mergeIntoTestClassError.message)
           );


### PR DESCRIPTION
### Context/purpose

Is it currently not possible to, for example, fetch results if an analysis object knows that it has ended due to a prior call to `getStatus`.

### Implementation details

Only require the analysis to have started to call `cancel`, `getStatus` and `getResults`, rather than be in progress.

### QA instructions

Try starting an analysis via `Analysis.run`, waiting for it to end, then call `getStatus`, `getResults` or `cancel`.

### Any unrelated changes?

Change enums to use singular naming, as in platform lite. Nice to be consistent and singular naming seems to be favoured in the community.

### PR Checklist

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
