### PR TITLE
Integrate the new STOPPING status. [TG-8157, TG-8161]

### DIFF
--- a/docs/programmatic-interface.md
+++ b/docs/programmatic-interface.md
@@ -249,7 +249,11 @@ const api = 'https://0.0.0.0/api';
 
 ### Get analysis status (Low level)
 
-Given an analysis identifier, returns the current analysis status, and progress. The possible statuses are: QUEUED, RUNNING, ERRORED, CANCELED and COMPLETED.
+Given an analysis identifier, returns the current analysis status, and progress. The possible statuses are: QUEUED, RUNNING, STOPPING, ERRORED, CANCELED and COMPLETED.
+
+A status of QUEUED, RUNNING or STOPPING indicates that the analysis is still in progress and that new results may still be returned.
+
+A status of ERRORED, CANCELED or COMPLETED indicates that the analysis has ended, and no further results are expected.
 
 The progress object returns the number of functions which have been analyzed compared to the total number to analyze.
 
@@ -323,13 +327,14 @@ import { delay } from 'bluebird';
 
 const api = 'https://0.0.0.0/api';
 const id = 'abcd1234-ab12-ab12-ab12-abcd12abcd12';
+const inProgressStatuses = new Set(['RUNNING', 'QUEUED', 'STOPPING' ]);
 
 (async () => {
   let results = [];
   let response;
   let nextCursor?: number;
 
-  while (!response || response.status.status === 'RUNNING' || response.status.status === 'QUEUED') {
+  while (!response || inProgressStatuses.has(response.status.status)) {
     response = await CoverClient.getAnalysisResults(api, id, nextCursor);
     console.log(
       `Status: ${response.status.status}`,

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -25,6 +25,8 @@ import {
   ApiErrorResponse,
   ApiVersionApiResponse,
   BindingsOptions,
+  endedStatuses,
+  inProgressStatuses,
   RunAnalysisOptions,
   WriteTestsOptions,
 } from './types/types';
@@ -240,6 +242,11 @@ export default class Analysis {
     return this.status === AnalysisStatus.RUNNING;
   }
 
+  /** Check if status is stopping */
+  public isStopping(): boolean {
+    return this.status === AnalysisStatus.STOPPING;
+  }
+
   /** Check if status is completed */
   public isCompleted(): boolean {
     return this.status === AnalysisStatus.COMPLETED;
@@ -265,16 +272,14 @@ export default class Analysis {
     if (!this.status) {
       return false;
     }
-    const endedStatuses = new Set([
-      AnalysisStatus.COMPLETED,
-      AnalysisStatus.ERRORED,
-      AnalysisStatus.CANCELED,
-    ]);
     return endedStatuses.has(this.status);
   }
 
   /** Check if status indicates that the analysis is in progress (started but not finished) */
   public isInProgress(): boolean {
-    return this.isQueued() || this.isRunning();
+    if (!this.status) {
+      return false;
+    }
+    return inProgressStatuses.has(this.status);
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,10 +4,14 @@
 export enum AnalysisStatus {
   QUEUED = 'QUEUED',
   RUNNING = 'RUNNING',
+  STOPPING = 'STOPPING',
   CANCELED = 'CANCELED',
   ERRORED = 'ERRORED',
   COMPLETED = 'COMPLETED',
 }
+
+export const inProgressStatuses = new Set([AnalysisStatus.QUEUED, AnalysisStatus.RUNNING, AnalysisStatus.STOPPING]);
+export const endedStatuses = new Set([AnalysisStatus.CANCELED, AnalysisStatus.ERRORED, AnalysisStatus.COMPLETED]);
 
 /**
  * An interface that contains all the possible files for

--- a/tests/unit/analysis.ts
+++ b/tests/unit/analysis.ts
@@ -391,7 +391,7 @@ describe('analysis', () => {
 
     describe('cancel', () => {
       const startResponse = { id: analysisId, phases: {}};
-      const cancelStatus = { status: AnalysisStatus.CANCELED, progress: { completed: 10, total: 20 }};
+      const cancelStatus = { status: AnalysisStatus.STOPPING, progress: { completed: 10, total: 20 }};
       const cancelMessage = 'Analysis cancelled successfully';
       const cancelResponse = { message: cancelMessage, status: cancelStatus };
 
@@ -736,6 +736,18 @@ describe('analysis', () => {
         const analysis = new Analysis(apiUrl);
         analysis.status = AnalysisStatus.COMPLETED;
         assert.strictEqual(analysis.isRunning(), false);
+      });
+
+      it('Knows if its status is stopping', () => {
+        const analysis = new Analysis(apiUrl);
+        analysis.status = AnalysisStatus.STOPPING;
+        assert.strictEqual(analysis.isStopping(), true);
+      });
+
+      it('Knows if its status is not stopping', () => {
+        const analysis = new Analysis(apiUrl);
+        analysis.status = AnalysisStatus.COMPLETED;
+        assert.strictEqual(analysis.isStopping(), false);
       });
 
       it('Knows if its status is canceled', () => {

--- a/tests/unit/bindings.ts
+++ b/tests/unit/bindings.ts
@@ -226,7 +226,7 @@ describe('api/bindings', () => {
       post.withArgs(cancelUrl).resolves({
         message: 'Analysis successfully canceled',
         status: {
-          status: 'CANCELED',
+          status: 'STOPPING',
           progress: 50,
         },
       });
@@ -236,7 +236,7 @@ describe('api/bindings', () => {
       const expectedResponse = {
         message: 'Analysis successfully canceled',
         status: {
-          status: 'CANCELED',
+          status: 'STOPPING',
           progress: 50,
         },
       };

--- a/tests/unit/utils/request.ts
+++ b/tests/unit/utils/request.ts
@@ -69,7 +69,7 @@ describe('utils/request', () => {
         data: {
           message: 'Analysis successfully canceled',
           status: {
-            status: 'CANCELED',
+            status: 'STOPPING',
             progress: 50,
           },
         },
@@ -79,7 +79,7 @@ describe('utils/request', () => {
       const expectedResponse = {
         message: 'Analysis successfully canceled',
         status: {
-          status: 'CANCELED',
+          status: 'STOPPING',
           progress: 50,
         },
       };


### PR DESCRIPTION
### Context/purpose

Platform lite will now return a new `STOPPING` status, which indicates that the analysis is still running but is in the process of stopping, i.e. all functions have been analysed but new results may still be returned.

See [platform#1988](https://github.com/diffblue/platform/pull/1988)

### Implementation details

Update the `Analysis` object to  understand the `STOPPING` status.
Update documentation and tests where required.

### QA instructions

No QA required, I think.

Could check if the `Analysis.run` method works correctly with a polling interval of 1 second, where you would expect to get back the `STOPPING` status at the end.

### Any unrelated changes?

Add and export 2 sets of analysis statuses (`inProgressStatuses`, `endedStatuses`), for reference internally or by end users.

### PR Checklist

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
