### PR TITLE
Preserve package path when writing tests [TG-8226]

### DIFF
--- a/docs/programmatic-interface.md
+++ b/docs/programmatic-interface.md
@@ -485,7 +485,7 @@ util.promisify(fs.readFile)('./FooBarTest.java').then((existingTestClass) => {
 });
 ```
 
-### Group results by tested function
+### Group results
 
 `generateTestClass` and `mergeIntoTestClass` expect the results they receive to all have the same `sourceFilePath` value.
 

--- a/src/writeTests.ts
+++ b/src/writeTests.ts
@@ -4,7 +4,7 @@ import { map } from 'bluebird';
 import { readFile, writeFile } from 'fs';
 import { isEmpty } from 'lodash';
 import * as mkdirp from 'mkdirp';
-import { join } from 'path';
+import { join, parse } from 'path';
 import { promisify } from 'util';
 
 import {
@@ -55,8 +55,9 @@ export default async function writeTests(
   const errors: { [sourceFilePath: string]: Error } = {};
   await dependencies.map(Object.entries(groupedResults), async ([sourceFilePath, results]) => {
     try {
+      const packagePath = parse(sourceFilePath).dir;
       const fileName = components.getFileNameForResult(results[0]);
-      const filePath = join(directoryPath, fileName);
+      const filePath = join(directoryPath, packagePath, fileName);
       let existingClass: Buffer | undefined;
       let testClass: string;
       try {

--- a/src/writeTests.ts
+++ b/src/writeTests.ts
@@ -56,8 +56,10 @@ export default async function writeTests(
   await dependencies.map(Object.entries(groupedResults), async ([sourceFilePath, results]) => {
     try {
       const packagePath = parse(sourceFilePath).dir;
+      const testDirectoryPath = join(directoryPath, packagePath);
+      await dependencies.mkdirp(testDirectoryPath);
       const fileName = components.getFileNameForResult(results[0]);
-      const filePath = join(directoryPath, packagePath, fileName);
+      const filePath = join(testDirectoryPath, fileName);
       let existingClass: Buffer | undefined;
       let testClass: string;
       try {

--- a/tests/tslint.json
+++ b/tests/tslint.json
@@ -3,6 +3,7 @@
     "../tslint.json"
   ],
   "rules": {
+    "no-any": false,
     "no-big-function": false,
     "no-identical-functions": false,
     "no-duplicate-string": false

--- a/tests/unit/bindings.ts
+++ b/tests/unit/bindings.ts
@@ -121,7 +121,6 @@ describe('api/bindings', () => {
 
     it('Throws an error when no build is supplied', sinonTest(async () => {
       await assert.rejectsWith(
-        // tslint:disable-next-line:no-any
         startAnalysis(api, { build: undefined } as any, settings),
         new BindingsError('The required `build` JAR file was not supplied', BindingsErrorCode.BUILD_MISSING),
       );
@@ -135,7 +134,7 @@ describe('api/bindings', () => {
       const expectedError = new RegExp(BindingsErrorCode.SETTINGS_INVALID);
 
       await assert.rejectsWith(
-        startAnalysis(api, { build: build }, obj as any), expectedError, // tslint:disable-line:no-any
+        startAnalysis(api, { build: build }, obj as any), expectedError,
       );
     }));
 

--- a/tests/unit/combiner.ts
+++ b/tests/unit/combiner.ts
@@ -111,7 +111,7 @@ describe('combiner', () => {
 
     it('Fails if no results passed', () => {
       assert.throws(
-        () => generateTestClass(undefined as any),  // tslint:disable-line:no-any
+        () => generateTestClass(undefined as any),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_MISSING;
         },
@@ -120,7 +120,7 @@ describe('combiner', () => {
 
     it('Fails if non array results passed', () => {
       assert.throws(
-        () => generateTestClass(new Set([sampleResult]) as any),  // tslint:disable-line:no-any
+        () => generateTestClass(new Set([sampleResult]) as any),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_TYPE;
         },
@@ -129,7 +129,7 @@ describe('combiner', () => {
 
     it('Fails if empty results passed', () => {
       assert.throws(
-        () => generateTestClass([] as any),  // tslint:disable-line:no-any
+        () => generateTestClass([] as any),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_EMPTY;
         },
@@ -170,7 +170,7 @@ describe('combiner', () => {
 
     it('Fails for an existing test class of the wrong type', async () => {
       await assert.rejects(
-        async () => mergeIntoTestClass(Buffer.alloc(0) as any, [sampleResult]), // tslint:disable-line:no-any
+        async () => mergeIntoTestClass(Buffer.alloc(0) as any, [sampleResult]),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.EXISTING_CLASS_TYPE;
         },
@@ -192,7 +192,7 @@ describe('combiner', () => {
     it('Fails if no results passed', async () => {
       const existingTestClass = 'test-class';
       await assert.rejects(
-        async () => mergeIntoTestClass(existingTestClass, undefined as any),  // tslint:disable-line:no-any
+        async () => mergeIntoTestClass(existingTestClass, undefined as any),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_MISSING;
         },
@@ -204,7 +204,7 @@ describe('combiner', () => {
       await assert.rejects(
         async () => mergeIntoTestClass(
           existingTestClass,
-          new Set([sampleResult]) as any,  // tslint:disable-line:no-any
+          new Set([sampleResult]) as any,
         ),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_TYPE;
@@ -215,7 +215,7 @@ describe('combiner', () => {
     it('Fails if empty results passed', async () => {
       const existingTestClass = 'test-class';
       await assert.rejects(
-        async () => mergeIntoTestClass(existingTestClass, [] as any),  // tslint:disable-line:no-any
+        async () => mergeIntoTestClass(existingTestClass, [] as any),
         (err: Error) => {
           return (err instanceof CombinerError) && err.code === CombinerErrorCode.RESULTS_EMPTY;
         },

--- a/tests/unit/utils/assertExtra.ts
+++ b/tests/unit/utils/assertExtra.ts
@@ -399,7 +399,6 @@ describe('utils/assertExtra', () => {
       });
 
       assert.throws(
-        // tslint:disable-next-line: no-any
         () => assertExtra.changedProperties(originalObject, changedObject, expectedChanges as any),
         errorEquals(expectedError),
       );

--- a/tests/unit/utils/spawnProcess.ts
+++ b/tests/unit/utils/spawnProcess.ts
@@ -49,7 +49,6 @@ class MockChildProcess {
 describe('utils/spawnProcess', () => {
   it('Resolves with stdout if the command succeeds', sinonTest(async (sinon) => {
     const childProcess = new MockChildProcess(true, 'stdout message', 'stderr message');
-    // tslint:disable-next-line: no-any
     const spawn = sinon.stub(dependencies, 'spawn').returns(childProcess as any);
 
     assert.strictEqual(await spawnProcess('command', ['action'], { shell: true }), 'stdout message');
@@ -58,7 +57,6 @@ describe('utils/spawnProcess', () => {
 
   it('Resolves with stdout if the command succeeds without stdio', sinonTest(async (sinon) => {
     const childProcess = new MockChildProcess(true);
-    // tslint:disable-next-line: no-any
     const spawn = sinon.stub(dependencies, 'spawn').returns(childProcess as any);
 
     assert.strictEqual(await spawnProcess('command', ['action'], { shell: true }), '');
@@ -67,7 +65,6 @@ describe('utils/spawnProcess', () => {
 
   it('Resolves with stdout if the command succeeds with default arguments and options', sinonTest(async (sinon) => {
     const childProcess = new MockChildProcess(true, 'stdout message', 'stderr message');
-    // tslint:disable-next-line: no-any
     const spawn = sinon.stub(dependencies, 'spawn').returns(childProcess as any);
 
     assert.strictEqual(await spawnProcess('command'), 'stdout message');
@@ -76,7 +73,6 @@ describe('utils/spawnProcess', () => {
 
   it('Rejects with stderr if the command fails', sinonTest(async (sinon) => {
     const childProcess = new MockChildProcess(false, 'stdout message', 'stderr message');
-    // tslint:disable-next-line: no-any
     const spawn = sinon.stub(dependencies, 'spawn').returns(childProcess as any);
 
     await assert.rejectsWith(spawnProcess('command', ['action']), new Error('stderr message'));

--- a/tests/unit/writeTests.ts
+++ b/tests/unit/writeTests.ts
@@ -30,293 +30,307 @@ const otherResult = {
   testedFunction: 'com.diffblue.other.OtherClass.otherFunction',
   sourceFilePath: '/com/diffblue/other/OtherClass.java',
 };
-const sampleResultFilePath = '/test/path/com/diffblue/javademo/TicTacToeTest.java';
-const otherResultFilePath = '/test/path/com/diffblue/other/OtherClassTest.java';
+const testDirPath = '/test/path';
+const sampleResultDirPath = `${testDirPath}/com/diffblue/javademo`;
+const sampleResultFilePath = `${sampleResultDirPath}/TicTacToeTest.java`;
+const otherResultDirPath = `${testDirPath}/com/diffblue/other`;
+const otherResultFilePath = `${otherResultDirPath}/OtherClassTest.java`;
 const enoentError = new TestError('File not found', 'ENOENT');
 
-describe('writer', () => {
-  describe('writeTests', () => {
+describe('writeTests', () => {
+  it('Can write tests to new files', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
+    const returnValue = await writeTests(testDirPath, [sampleResult, otherResult]);
+    const expectedReturn = [sampleResultFilePath, otherResultFilePath];
+    assert.deepStrictEqual(returnValue, expectedReturn);
+    sinonAssert.calledThrice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledWithExactly(mkdirp, otherResultDirPath);
+    sinonAssert.calledTwice(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledWithExactly(readFile, otherResultFilePath);
+    sinonAssert.calledTwice(generateTestClass);
+    sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
+    sinonAssert.calledWithExactly(generateTestClass, [otherResult]);
+    sinonAssert.calledTwice(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+    sinonAssert.calledWithExactly(writeFile, otherResultFilePath, 'test-class');
+  }));
 
-    it('Can write tests to new files', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
-      const returnValue = await writeTests('/test/path', [sampleResult, otherResult]);
-      const expectedReturn = [sampleResultFilePath, otherResultFilePath];
-      assert.deepStrictEqual(returnValue, expectedReturn);
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledTwice(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledWithExactly(readFile, otherResultFilePath);
-      sinonAssert.calledTwice(generateTestClass);
-      sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
-      sinonAssert.calledWithExactly(generateTestClass, [otherResult]);
-      sinonAssert.calledTwice(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-      sinonAssert.calledWithExactly(writeFile, otherResultFilePath, 'test-class');
-    }));
+  it('Can write tests to existing files', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    const returnValue = await writeTests(testDirPath, [sampleResult, otherResult]);
+    const expectedReturn = [sampleResultFilePath, otherResultFilePath];
+    assert.deepStrictEqual(returnValue, expectedReturn);
+    sinonAssert.calledThrice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledWithExactly(mkdirp, otherResultDirPath);
+    sinonAssert.calledTwice(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledWithExactly(readFile, otherResultFilePath);
+    sinonAssert.calledTwice(mergeIntoTestClass);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [otherResult]);
+    sinonAssert.calledTwice(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+    sinonAssert.calledWithExactly(writeFile, otherResultFilePath, 'test-class');
+  }));
 
-    it('Can write tests to existing files', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      const returnValue = await writeTests('/test/path', [sampleResult, otherResult]);
-      const expectedReturn = [sampleResultFilePath, otherResultFilePath];
-      assert.deepStrictEqual(returnValue, expectedReturn);
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledTwice(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledWithExactly(readFile, otherResultFilePath);
-      sinonAssert.calledTwice(mergeIntoTestClass);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [otherResult]);
-      sinonAssert.calledTwice(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-      sinonAssert.calledWithExactly(writeFile, otherResultFilePath, 'test-class');
-    }));
+  it('Can write tests with matching file names and differing package paths', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
+    const similarResult = clone(sampleResult);
+    similarResult.sourceFilePath = '/com/diffblue/other/TicTacToe.java';
+    const similarResultFilePath = '/test/path/com/diffblue/other/TicTacToeTest.java';
+    const returnValue = await writeTests(testDirPath, [sampleResult, similarResult]);
+    const expectedReturn = [sampleResultFilePath, similarResultFilePath];
+    assert.deepStrictEqual(returnValue, expectedReturn);
+    sinonAssert.calledThrice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledWithExactly(mkdirp, otherResultDirPath);
+    sinonAssert.calledTwice(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledWithExactly(readFile, similarResultFilePath);
+    sinonAssert.calledTwice(generateTestClass);
+    sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
+    sinonAssert.calledWithExactly(generateTestClass, [similarResult]);
+    sinonAssert.calledTwice(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+    sinonAssert.calledWithExactly(writeFile, similarResultFilePath, 'test-class');
+  }));
 
-    it('Can write tests with matching file names and differing package paths', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
-      const similarResult = clone(sampleResult);
-      similarResult.sourceFilePath = '/com/diffblue/other/TicTacToe.java';
-      const similarResultFilePath = '/test/path/com/diffblue/other/TicTacToeTest.java';
-      const returnValue = await writeTests('/test/path', [sampleResult, similarResult]);
-      const expectedReturn = [sampleResultFilePath, similarResultFilePath];
-      assert.deepStrictEqual(returnValue, expectedReturn);
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledTwice(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledWithExactly(readFile, similarResultFilePath);
-      sinonAssert.calledTwice(generateTestClass);
-      sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
-      sinonAssert.calledWithExactly(generateTestClass, [similarResult]);
-      sinonAssert.calledTwice(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-      sinonAssert.calledWithExactly(writeFile, similarResultFilePath, 'test-class');
-    }));
+  it('Can accept options to set map concurrency', sinonTest(async (sinon) => {
+    sinon.stub(dependencies, 'mkdirp').resolves();
+    const map = sinon.stub(dependencies, 'map').resolves();
+    await writeTests(testDirPath, [sampleResult], { concurrency: 1 });
+    assert.deepStrictEqual(map.firstCall.args[2], { concurrency: 1 });
+  }));
 
-    it('Can accept options to set map concurrency', sinonTest(async (sinon) => {
-      sinon.stub(dependencies, 'mkdirp').resolves();
-      const map = sinon.stub(dependencies, 'map').resolves();
-      await writeTests('/test/path', [sampleResult], { concurrency: 1 });
-      assert.deepStrictEqual(map.firstCall.args[2], { concurrency: 1 });
-    }));
+  it('Rejects if readFile rejects with non ENOENT error', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
+    const readFileError = new Error('readFile threw');
+    const readFile = sinon.stub(dependencies, 'readFile').rejects(readFileError);
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(readFileError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledOnce(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.notCalled(generateTestClass);
+    sinonAssert.notCalled(writeFile);
+  }));
 
-    it('Rejects if readFile rejects with non ENOENT error', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
-      const readFileError = new Error('readFile threw');
-      const readFile = sinon.stub(dependencies, 'readFile').rejects(readFileError);
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(readFileError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledOnce(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.notCalled(generateTestClass);
-      sinonAssert.notCalled(writeFile);
-    }));
+  it('Rejects if generateTestClass throws', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const generateTestClassError = new Error('generateTestClass threw');
+    const generateTestClass = sinon.stub(components, 'generateTestClass').throws(generateTestClassError);
+    const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(generateTestClassError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledOnce(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledOnce(generateTestClass);
+    sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
+    sinonAssert.notCalled(writeFile);
+  }));
 
-    it('Rejects if generateTestClass throws', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const generateTestClassError = new Error('generateTestClass threw');
-      const generateTestClass = sinon.stub(components, 'generateTestClass').throws(generateTestClassError);
-      const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(generateTestClassError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledOnce(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledOnce(generateTestClass);
-      sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
-      sinonAssert.notCalled(writeFile);
-    }));
+  it('Rejects if mergeIntoTestClass rejects', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').rejects(mergeIntoTestClassError);
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(mergeIntoTestClassError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledOnce(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledOnce(mergeIntoTestClass);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
+    sinonAssert.notCalled(writeFile);
+  }));
 
-    it('Rejects if mergeIntoTestClass rejects', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').rejects(mergeIntoTestClassError);
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(mergeIntoTestClassError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledOnce(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledOnce(mergeIntoTestClass);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
-      sinonAssert.notCalled(writeFile);
-    }));
+  it('Rejects if writeFile throws when writing new files', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFileError = new Error('writeFile rejected');
+    const writeFile = sinon.stub(dependencies, 'writeFile').rejects(writeFileError);
+    const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(writeFileError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledOnce(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledOnce(generateTestClass);
+    sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
+    sinonAssert.calledOnce(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+  }));
 
-    it('Rejects if writeFile throws when writing new files', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFileError = new Error('writeFile rejected');
-      const writeFile = sinon.stub(dependencies, 'writeFile').rejects(writeFileError);
-      const generateTestClass = sinon.stub(components, 'generateTestClass').returns('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').rejects(enoentError);
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(writeFileError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledOnce(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledOnce(generateTestClass);
-      sinonAssert.calledWithExactly(generateTestClass, [sampleResult]);
-      sinonAssert.calledOnce(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-    }));
+  it('Rejects if writeFile throws when writing to existing files', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFileError = new Error('writeFile rejected');
+    const writeFile = sinon.stub(dependencies, 'writeFile').rejects(writeFileError);
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(writeFileError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledOnce(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledOnce(mergeIntoTestClass);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
+    sinonAssert.calledOnce(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+  }));
 
-    it('Rejects if writeFile throws when writing to existing files', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFileError = new Error('writeFile rejected');
-      const writeFile = sinon.stub(dependencies, 'writeFile').rejects(writeFileError);
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(writeFileError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledOnce(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledOnce(mergeIntoTestClass);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
-      sinonAssert.calledOnce(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-    }));
+  it('Rejects if there is an error creating the output directory', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').rejects();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.DIR_FAILED
+        );
+      },
+    );
+    sinonAssert.calledOnce(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.notCalled(readFile);
+    sinonAssert.notCalled(mergeIntoTestClass);
+    sinonAssert.notCalled(writeFile);
+  }));
 
-    it('Rejects if there is an error creating the output directory', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').rejects();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.DIR_FAILED
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.notCalled(readFile);
-      sinonAssert.notCalled(mergeIntoTestClass);
-      sinonAssert.notCalled(writeFile);
-    }));
+  it('Rejects if getFileNameForResult throws', sinonTest(async (sinon) => {
+    const getFileNameForResultError = new Error('getFileNameForResult threw');
+    sinon.stub(components, 'getFileNameForResult').throws(getFileNameForResultError);
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').rejects(mergeIntoTestClassError);
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
+          && err.message.includes(getFileNameForResultError.message)
+        );
+      },
+    );
+    sinonAssert.calledTwice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.notCalled(readFile);
+    sinonAssert.notCalled(mergeIntoTestClass);
+    sinonAssert.notCalled(writeFile);
+  }));
 
-    it('Rejects if getFileNameForResult throws', sinonTest(async (sinon) => {
-      const getFileNameForResultError = new Error('getFileNameForResult threw');
-      sinon.stub(components, 'getFileNameForResult').throws(getFileNameForResultError);
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').rejects(mergeIntoTestClassError);
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${sampleResult.sourceFilePath}`)
-            && err.message.includes(getFileNameForResultError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.notCalled(readFile);
-      sinonAssert.notCalled(mergeIntoTestClass);
-      sinonAssert.notCalled(writeFile);
-    }));
-
-    it('Writes some test files even if it rejects at least once when writing', sinonTest(async (sinon) => {
-      const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
-      const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
-      const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
-      const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
-      const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
-      // mergeIntoTestClass rejects when called for other result, but writeFile is still called for sampleResult
-      mergeIntoTestClass.withArgs('existing-test-class', [otherResult]).rejects(mergeIntoTestClassError);
-      await assert.rejects(
-        async () => writeTests('/test/path', [sampleResult, otherResult]),
-        (err: Error) => {
-          return (
-            (err instanceof WriterError)
-            && err.code === WriterErrorCode.WRITE_FAILED
-            && err.message.includes(`sourceFilePath: ${otherResult.sourceFilePath}`)
-            && err.message.includes(mergeIntoTestClassError.message)
-          );
-        },
-      );
-      sinonAssert.calledOnce(mkdirp);
-      sinonAssert.calledWithExactly(mkdirp, '/test/path');
-      sinonAssert.calledTwice(readFile);
-      sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
-      sinonAssert.calledWithExactly(readFile, otherResultFilePath);
-      sinonAssert.calledTwice(mergeIntoTestClass);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
-      sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [otherResult]);
-      sinonAssert.calledOnce(writeFile);
-      sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
-    }));
-  });
+  it('Writes some test files even if it rejects at least once when writing', sinonTest(async (sinon) => {
+    const mkdirp = sinon.stub(dependencies, 'mkdirp').resolves();
+    const writeFile = sinon.stub(dependencies, 'writeFile').resolves();
+    const mergeIntoTestClassError = new Error('mergeIntoTestClass rejected');
+    const mergeIntoTestClass = sinon.stub(components, 'mergeIntoTestClass').resolves('test-class');
+    const readFile = sinon.stub(dependencies, 'readFile').resolves('existing-test-class');
+    // mergeIntoTestClass rejects when called for other result, but writeFile is still called for sampleResult
+    mergeIntoTestClass.withArgs('existing-test-class', [otherResult]).rejects(mergeIntoTestClassError);
+    await assert.rejects(
+      async () => writeTests(testDirPath, [sampleResult, otherResult]),
+      (err: Error) => {
+        return (
+          (err instanceof WriterError)
+          && err.code === WriterErrorCode.WRITE_FAILED
+          && err.message.includes(`sourceFilePath: ${otherResult.sourceFilePath}`)
+          && err.message.includes(mergeIntoTestClassError.message)
+        );
+      },
+    );
+    sinonAssert.calledThrice(mkdirp);
+    sinonAssert.calledWithExactly(mkdirp, testDirPath);
+    sinonAssert.calledWithExactly(mkdirp, sampleResultDirPath);
+    sinonAssert.calledWithExactly(mkdirp, otherResultDirPath);
+    sinonAssert.calledTwice(readFile);
+    sinonAssert.calledWithExactly(readFile, sampleResultFilePath);
+    sinonAssert.calledWithExactly(readFile, otherResultFilePath);
+    sinonAssert.calledTwice(mergeIntoTestClass);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [sampleResult]);
+    sinonAssert.calledWithExactly(mergeIntoTestClass, 'existing-test-class', [otherResult]);
+    sinonAssert.calledOnce(writeFile);
+    sinonAssert.calledWithExactly(writeFile, sampleResultFilePath, 'test-class');
+  }));
 });


### PR DESCRIPTION
### Context/purpose

The client library currently dumps all test files directly into the user specified test directly, but should preserve the package path (e.g. `com/diffblue/javademo/`).

### Implementation details

Use the `sourceFilePath` directory when working out where a test file should be written/may exist.

### QA instructions

Use `Analysis.run` (or `writeTests`) to write test files, you should see them written with the package path preserved .e.g `testDir/com/diffblue/javademo/TicTacToeTest.java`.

### Any unrelated changes?

Fix docs section title.

Disable `no-any` tslint rule in tests, remove disable comments.

### PR Checklist

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
