### PR TITLE
Enforce import groups with tslint.

### DIFF
--- a/src/utils/commandLineRunner.ts
+++ b/src/utils/commandLineRunner.ts
@@ -1,6 +1,7 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import { basename } from 'path';
+
 import argvParser, { Options } from './argvParser';
 import logger from './log';
 import multiline from './multiline';

--- a/src/utils/createPullRequest.ts
+++ b/src/utils/createPullRequest.ts
@@ -1,7 +1,6 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import spawnProcess from '../utils/spawnProcess';
-
 import { ExpectedError } from './commandLineRunner';
 
 export const dependencies = {

--- a/tests/integration/combiner.ts
+++ b/tests/integration/combiner.ts
@@ -5,9 +5,8 @@ import { groupBy, mapValues } from 'lodash';
 import { promisify } from 'util';
 
 import { generateTestClass, mergeIntoTestClass } from '../../src/combiner';
-import assert from '../../src/utils/assertExtra';
-
 import { AnalysisResult } from '../../src/types/types';
+import assert from '../../src/utils/assertExtra';
 
 const readFile = promisify(readFileCallback);
 

--- a/tests/unit/analysis.ts
+++ b/tests/unit/analysis.ts
@@ -2,12 +2,11 @@
 
 import { clone } from 'lodash';
 
-import assert from '../../src/utils/assertExtra';
-import sinonTestFactory from '../../src/utils/sinonTest';
-
 import Analysis, { components } from '../../src/analysis';
 import { AnalysisError, AnalysisErrorCode } from '../../src/errors';
 import { AnalysisStatus } from '../../src/types/types';
+import assert from '../../src/utils/assertExtra';
+import sinonTestFactory from '../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 const sinonTestWithTimers = sinonTestFactory({ useFakeTimers: false });

--- a/tests/unit/scripts/copyrightChecker.ts
+++ b/tests/unit/scripts/copyrightChecker.ts
@@ -1,10 +1,5 @@
 // Copyright 2017-2019 Diffblue Limited. All Rights Reserved.
 
-import assert from '../../../src/utils/assertExtra';
-import multiline from '../../../src/utils/multiline';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-import TestError from '../../../src/utils/TestError';
-
 import copyrightChecker, {
   buildFileList,
   catchMissingFile,
@@ -16,6 +11,10 @@ import copyrightChecker, {
   mapRootRelativeRules,
   parseGitignore,
 } from '../../../src/scripts/copyrightChecker';
+import assert from '../../../src/utils/assertExtra';
+import multiline from '../../../src/utils/multiline';
+import sinonTestFactory from '../../../src/utils/sinonTest';
+import TestError from '../../../src/utils/TestError';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/scripts/createPostReleasePullRequest.ts
+++ b/tests/unit/scripts/createPostReleasePullRequest.ts
@@ -1,12 +1,11 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
-import assert from '../../../src/utils/assertExtra';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import createPostReleasePullRequest, {
   components,
   dependencies,
 } from '../../../src/scripts/createPostReleasePullRequest';
+import assert from '../../../src/utils/assertExtra';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/scripts/createRelease.ts
+++ b/tests/unit/scripts/createRelease.ts
@@ -1,6 +1,7 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import { StatusResult } from 'simple-git/promise';
+
 import createRelease, {
   checkPrerequisites,
   commitPackageJsonChange,

--- a/tests/unit/scripts/createReleaseTag.ts
+++ b/tests/unit/scripts/createReleaseTag.ts
@@ -1,9 +1,8 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
+import createReleaseTag, { dependencies } from '../../../src/scripts/createReleaseTag';
 import assert from '../../../src/utils/assertExtra';
 import sinonTestFactory from '../../../src/utils/sinonTest';
-
-import createReleaseTag, { dependencies } from '../../../src/scripts/createReleaseTag';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/scripts/licenseChecker.ts
+++ b/tests/unit/scripts/licenseChecker.ts
@@ -1,8 +1,5 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
-import assert from '../../../src/utils/assertExtra';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import licenseChecker, {
   checkLicenses,
   Command,
@@ -15,7 +12,9 @@ import licenseChecker, {
   loadAcceptableLicenses,
   parseLicenseInfo,
 } from '../../../src/scripts/licenseChecker';
+import assert from '../../../src/utils/assertExtra';
 import multiline from '../../../src/utils/multiline';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/scripts/publishPackage.ts
+++ b/tests/unit/scripts/publishPackage.ts
@@ -1,10 +1,5 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
-import assert from '../../../src/utils/assertExtra';
-import { ExpectedError } from '../../../src/utils/commandLineRunner';
-import multiline from '../../../src/utils/multiline';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import publishPackage, {
   AuthenticatedCallback,
   authenticateNpm,
@@ -13,6 +8,10 @@ import publishPackage, {
   extractNpmError,
   getAuthUser,
 } from '../../../src/scripts/publishPackage';
+import assert from '../../../src/utils/assertExtra';
+import { ExpectedError } from '../../../src/utils/commandLineRunner';
+import multiline from '../../../src/utils/multiline';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/utils/CancellableDelay.ts
+++ b/tests/unit/utils/CancellableDelay.ts
@@ -1,9 +1,8 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import assert from '../../../src/utils/assertExtra';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import CancellableDelay from '../../../src/utils/CancellableDelay';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory({ useFakeTimers: false });
 

--- a/tests/unit/utils/argvParser.ts
+++ b/tests/unit/utils/argvParser.ts
@@ -1,8 +1,7 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
-import assert from '../../../src/utils/assertExtra';
-
 import argvParser, { splitOnce } from '../../../src/utils/argvParser';
+import assert from '../../../src/utils/assertExtra';
 
 describe('utils/argvParser', () => {
   describe('splitOnce', () => {

--- a/tests/unit/utils/commandLineRunner.ts
+++ b/tests/unit/utils/commandLineRunner.ts
@@ -1,9 +1,6 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import assert from '../../../src/utils/assertExtra';
-import multiline from '../../../src/utils/multiline';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import commandLineRunner, {
   components,
   dependencies,
@@ -12,6 +9,8 @@ import commandLineRunner, {
   getHelpMessage,
   indent,
 } from '../../../src/utils/commandLineRunner';
+import multiline from '../../../src/utils/multiline';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/utils/createPullRequest.ts
+++ b/tests/unit/utils/createPullRequest.ts
@@ -2,9 +2,8 @@
 
 import assert from '../../../src/utils/assertExtra';
 import { ExpectedError } from '../../../src/utils/commandLineRunner';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import createPullRequest, { dependencies } from '../../../src/utils/createPullRequest';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/utils/getPackageJson.ts
+++ b/tests/unit/utils/getPackageJson.ts
@@ -1,9 +1,8 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import assert from '../../../src/utils/assertExtra';
-import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import getPackageJson, { dependencies } from '../../../src/utils/getPackageJson';
+import sinonTestFactory from '../../../src/utils/sinonTest';
 
 const sinonTest = sinonTestFactory();
 

--- a/tests/unit/utils/multiline.ts
+++ b/tests/unit/utils/multiline.ts
@@ -1,7 +1,6 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
 import assert from '../../../src/utils/assertExtra';
-
 import multiline from '../../../src/utils/multiline';
 
 describe('utils/multiline', () => {

--- a/tests/unit/utils/sinonTest.ts
+++ b/tests/unit/utils/sinonTest.ts
@@ -4,7 +4,6 @@ import { delay } from 'bluebird';
 import * as sinon from 'sinon';
 
 import assert from '../../../src/utils/assertExtra';
-
 import sinonTest from '../../../src/utils/sinonTest';
 
 // "You're very clever, young man, very clever, but it's turtles all the way down!"

--- a/tests/unit/utils/spawnProcess.ts
+++ b/tests/unit/utils/spawnProcess.ts
@@ -4,7 +4,6 @@ import { Readable } from 'stream';
 
 import assert from '../../../src/utils/assertExtra';
 import sinonTestFactory from '../../../src/utils/sinonTest';
-
 import spawnProcess, { dependencies } from '../../../src/utils/spawnProcess';
 
 const sinonTest = sinonTestFactory({ useFakeTimers: false });

--- a/tests/unit/writeTests.ts
+++ b/tests/unit/writeTests.ts
@@ -2,11 +2,10 @@
 
 import { assert as sinonAssert } from 'sinon';
 
+import { WriterError, WriterErrorCode } from '../../src/errors';
 import assert from '../../src/utils/assertExtra';
 import sinonTestFactory from '../../src/utils/sinonTest';
 import TestError from '../../src/utils/TestError';
-
-import { WriterError, WriterErrorCode } from '../../src/errors';
 import writeTests, { components, dependencies } from '../../src/writeTests';
 
 const sinonTest = sinonTestFactory();

--- a/tslint.json
+++ b/tslint.json
@@ -131,7 +131,12 @@
       {
         "import-sources-order": "case-insensitive",
         "module-source-path": "full",
-        "named-imports-order": "case-insensitive"
+        "named-imports-order": "case-insensitive",
+        "grouped-imports": true,
+        "groups": [
+          { "name": "local files", "match": "^\\.", "order": 20 },
+          { "name": "libraries", "match": ".*", "order": 10 }
+        ]
       }
     ],
     "prefer-const": true,


### PR DESCRIPTION
### Context/purpose

Import grouping should be non-controversial and automatable: tslint to the rescue!

TODO in platform lite as well if this passes review.

### Implementation details

Add rule config to require imports to be split into two groups, libraries (first) and local files (second).

N.B. This is auto-fixable.

### QA instructions

No QA.

### Any unrelated changes?

<!-- Anything unrelated included in this PR (remove section if empty) -->

### PR Checklist

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
