### PR TITLE
Bump typescript to v3.5.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "tslint": "5.15.0",
     "tslint-eslint-rules": "5.4.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "3.4.3",
+    "typescript": "3.5.2",
     "typescript-tslint-plugin": "0.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ typescript-tslint-plugin@0.3.1:
     mock-require "^3.0.2"
     vscode-languageserver "^5.1.0"
 
-typescript@3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
### Context/purpose

We are now one minor version of date for typescript.

### Implementation details

Bump to v3.5.2. No sign of any breaking changes affecting us.

See:
[Whats new in 3.5](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#typescript-35)
[Breaking changes in 3.5](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-35)
[releases](https://github.com/microsoft/TypeScript/releases)

### QA instructions

No QA.

### PR Checklist

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
