### PR TITLE
Update to account for changes in API spec and java-combiner behaviour [TG-9453]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ references:
   node-10: &node-10
     circleci/node:10.15.3
   node-12: &node-12
-    circleci/node:12.3.1
+    circleci/node:12.10.0
 
 commands:
   install-hub:

--- a/docs/programmatic-interface.md
+++ b/docs/programmatic-interface.md
@@ -133,9 +133,9 @@ const analysis = new Analysis('https://your-cover-api-domain.com');
 const buildFile = createReadStream('./build.jar');
 
 (async () => {
-  const { id, phases } = await analysis.start({ build: buildFile };
+  const { id, settings } = await analysis.start({ build: buildFile };
   console.log(`Analysis identifier: ${id}`);
-  console.log(`Analysis computed phases: ${phases}`);
+  console.log(`Analysis computed settings: ${settings}`);
 }();
 ```
 
@@ -149,12 +149,12 @@ const files = {
   baseBuild: createReadStream('./baseBuild.jar'),
   dependenciesBuild: createReadStream('./dependenciesBuild.jar'),
 };
-const settings = { ignoreDefaults: false, phases: {}};
+const userSettings = { ignoreDefaults: false, phases: {}};
 
 (async () => {
-  const { id, phases } = await analysis.start(files, settings);
+  const { id, settings } = await analysis.start(files, userSettings);
   console.log(`Analysis identifier: ${id}`);
-  console.log(`Analysis computed phases: ${phases}`);
+  console.log(`Analysis computed settings: ${settings}`);
 }();
 ```
 
@@ -321,10 +321,10 @@ const fs = require('fs');
 const api = 'https://0.0.0.0/api';
 const build = fs.createReadStream('./build.jar');
 
-return CoverClient.startAnalysis(api, { build: build }).then(({ id, phases }) => {
+return CoverClient.startAnalysis(api, { build: build }).then(({ id, settings }) => {
   console.log([
     `Analysis identifier: ${id}`,
-    `Phases: ${phases}\n`
+    `Settings: ${settings}\n`
   ].join('\n'));
 });
 ```
@@ -342,18 +342,18 @@ const api = 'https://0.0.0.0/api';
   const build = await promisify(readFile)('./build.jar');
   const baseBuild = await promisify(readFile)('./baseBuild.jar');
   const dependenciesBuild = await promisify(readFile)('./dependenciesBuild.jar');
-  const settings = { ignoreDefaults: false, phases: {}};
+  const userSettings = { ignoreDefaults: false, phases: {}};
   const files = {
     baseBuild: baseBuild,
     build: build,
     dependenciesBuild: dependenciesBuild,
   };
 
-  const { id, phases } = await CoverClient.startAnalysis(api, files, settings);
+  const { id, settings } = await CoverClient.startAnalysis(api, files, userSettings);
 
   console.log([
     `Analysis identifier: ${id}`,
-    `Phases: ${phases}\n`
+    `Settings: ${settings}\n`
   ].join('\n'));
 })();
 ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-unit": "mocha --require ts-node/register 'tests/unit/**/*.ts'"
   },
   "dependencies": {
-    "@diffblue/java-combiner": "0.1.6",
+    "@diffblue/java-combiner": "0.1.7",
     "axios": "0.19.0",
     "bluebird": "^3.5.5",
     "form-data": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-unit": "mocha --require ts-node/register 'tests/unit/**/*.ts'"
   },
   "dependencies": {
-    "@diffblue/java-combiner": "0.1.7",
+    "@diffblue/java-combiner": "0.1.8",
     "axios": "0.19.0",
     "bluebird": "^3.5.5",
     "form-data": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-unit": "mocha --require ts-node/register 'tests/unit/**/*.ts'"
   },
   "dependencies": {
-    "@diffblue/java-combiner": "0.1.3",
+    "@diffblue/java-combiner": "0.1.6",
     "axios": "0.19.0",
     "bluebird": "^3.5.5",
     "form-data": "2.3.3",

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -14,7 +14,6 @@ import { AnalysisError, AnalysisErrorCode } from './errors';
 import {
   AnalysisCancelApiResponse,
   AnalysisFiles,
-  AnalysisPhases,
   AnalysisProgress,
   AnalysisResult,
   AnalysisResultsApiResponse,
@@ -52,7 +51,7 @@ export default class Analysis {
   public status?: AnalysisStatus;
   public progress?: AnalysisProgress;
   public error?: ApiErrorResponse;
-  public phases?: AnalysisPhases;
+  public computedSettings?: AnalysisSettings;
   public results: AnalysisResult[] = [];
   public cursor?: number;
   public apiVersion?: string;
@@ -184,7 +183,7 @@ export default class Analysis {
     const response = await components.startAnalysis(this.apiUrl, files, settings, this.bindingsOptions);
     this.settings = settings;
     this.analysisId = response.id;
-    this.phases = response.phases;
+    this.computedSettings = response.settings;
     this.status = AnalysisStatus.QUEUED;
     return response;
   }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -46,7 +46,7 @@ export async function getApiVersion(api: string, options?: BindingsOptions): Pro
   return dependencies.request.get(dependencies.routes.version(api), convertOptions(options));
 }
 
-/** Starts an analysis and returns the analysis id */
+/** Starts an analysis and returns the analysis id and computed settings */
 export async function startAnalysis(
   api: string,
   { baseBuild, build, dependenciesBuild }: AnalysisFiles,

--- a/src/combiner.ts
+++ b/src/combiner.ts
@@ -110,6 +110,7 @@ function checkExistingClass(existingClass: string): void {
 export function prepareTestData(results: AnalysisResult[]): ITestData[] {
   return results.map(({
       classAnnotations,
+      classRules,
       coveredLines,
       imports,
       sourceFilePath,
@@ -121,6 +122,7 @@ export function prepareTestData(results: AnalysisResult[]): ITestData[] {
     return {
       body: testBody,
       classAnnotations: classAnnotations,
+      classRules: classRules,
       coveredLines: coveredLines,
       id: testId,
       imports: imports,

--- a/src/combiner.ts
+++ b/src/combiner.ts
@@ -108,13 +108,24 @@ function checkExistingClass(existingClass: string): void {
 
 /** Map AnalysisResults to ITestData */
 export function prepareTestData(results: AnalysisResult[]): ITestData[] {
-  return results.map(({ classAnnotations, imports, staticImports, testName, testBody, testId }) => {
+  return results.map(({
+      classAnnotations,
+      coveredLines,
+      imports,
+      sourceFilePath,
+      staticImports,
+      testBody,
+      testId ,
+      testName,
+    }) => {
     return {
-      id: testId,
-      name: testName,
       body: testBody,
       classAnnotations: classAnnotations,
+      coveredLines: coveredLines,
+      id: testId,
       imports: imports,
+      name: testName,
+      sourceFilePath: sourceFilePath,
       staticImports: staticImports,
     };
   });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -38,6 +38,7 @@ export interface ApiErrorResponse {
 /** Analysis result returned by API */
 export interface AnalysisResult {
   classAnnotations: string[];
+  classRules: string[];
   coveredLines: string[];
   createdTime: string;
   imports: string[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -37,44 +37,55 @@ export interface ApiErrorResponse {
 
 /** Analysis result returned by API */
 export interface AnalysisResult {
+  classAnnotations: string[];
+  coveredLines: string[];
+  createdTime: string;
+  imports: string[];
+  phaseGenerated: string;
+  sourceFilePath: string;
+  staticImports: string[];
+  tags: string[];
+  testBody: string;
+  testedFunction: string;
   testId: string;
   testName: string;
-  testedFunction: string;
-  sourceFilePath: string;
-  testBody: string;
-  imports: string[];
-  staticImports: string[];
-  classAnnotations: string[];
-  tags: string[];
-  phaseGenerated: string;
-  createdTime: string;
 }
 
 /** Analysis phase returned and consumed by the API */
 export interface AnalysisPhase {
-  initial?: boolean;
-  timeout: number;
   classpath?: string;
   depth?: number;
+  doNotTestMethodsWithAccess?: ['public' | 'protected' | 'default' | 'private'];
+  initial?: boolean;
+  inlineFunctionArguments?: boolean;
+  inlineIntoAssertion?: boolean;
+  javaAssumeInputsIntegral?: boolean;
+  javaAssumeInputsNonNull?: boolean;
   javaExternalCodeAction?: 'mock' | 'mock-non-jdk' | 'ignore' | 'discard-testcase';
+  javaGenerateNoComments?: boolean;
   javaLoadClass?: string[];
   javaMaxVlaLength?: number;
   javaMockClass?: string[];
-  javaUnwindEnumStatic?: boolean;
-  maxNondetStringLength?: number;
-  unwind?: number;
-  stringPrintable?: boolean;
-  maxNondetArrayLength?: number;
-  throwRuntimeExceptions?: boolean;
-  coverFunctionOnly?: boolean;
   javaTestInputFactory?: string[];
   javaTestInputFactoryBmcMaxMutators?: number;
   javaTestInputFactoryBmcRecursionLimit?: number;
   javaTestInputFactoryEntryPoint?: string[];
   javaTestOutputEntryPoint?: string[];
-  nextPhase?: {
-    [event: string]: string;
-  };
+  javaUnwindEnumStatic?: boolean;
+  loadContainingClassOnly?: boolean;
+  maxNondetArrayLength?: number;
+  maxNondetStringLength?: number;
+  nextPhase?: { [event: string]: string | null };
+  noReflectiveAsserts?: boolean;
+  paths?: 'fifo' | 'lifo';
+  preferDepsJar?: boolean;
+  singleFunctionOnly?: boolean;
+  smartHarness?: 'nondet' | 'simplest-constructor-and-nondet' | 'input-factory';
+  staticValuesJson?: boolean;
+  stringPrintable?: boolean;
+  throwRuntimeExceptions?: boolean;
+  timeout: number;
+  unwind?: number;
 }
 
 /**
@@ -102,15 +113,20 @@ export interface PartialAnalysisPhases {
 
 /** Settings parameter require to start an analysis */
 export interface AnalysisSettings {
-  include?: string[];
-  exclude?: string[];
-  context?: {
-    include?: string[];
-    exclude?: string[];
-  };
+  cover?: string[];
+  coverExcludeBytecode?: string[];
+  coverExcludeLines?: string[];
+  coverFunctionOnly?: boolean;
+  coverIncludeBytecode?: string[];
+  coverIncludeLines?: string[];
+  coverIncludePattern?: string;
+  coverOnly?: 'file' | 'function';
+  dependenciesOnClasspath?: Array<{classFile: string, source: string}>;
+  entryPointsExclude?: string[];
+  entryPointsInclude?: string[];
   ignoreDefaults?: boolean;
-  phases?: PartialAnalysisPhases;
   phaseBase?: PartialAnalysisPhase;
+  phases?: PartialAnalysisPhases;
 }
 
 /** Status object returned by the API */
@@ -123,7 +139,7 @@ export interface AnalysisStatusApiResponse {
 /** Object returned by the API on analysis start */
 export interface AnalysisStartApiResponse {
   id: string;
-  phases: AnalysisPhases;
+  settings: AnalysisSettings;
 }
 
 /** Object returned by the API on analysis cancellation */

--- a/tests/integration/combiner.ts
+++ b/tests/integration/combiner.ts
@@ -1,14 +1,21 @@
 // Copyright 2019 Diffblue Limited. All Rights Reserved.
 
-import { readFile as readFileCallback } from 'fs';
+import { readFile as readFileCallback, writeFile as writeFileCallback } from 'fs';
 import { groupBy, mapValues } from 'lodash';
 import { promisify } from 'util';
 
 import { generateTestClass, mergeIntoTestClass } from '../../src/combiner';
 import { AnalysisResult } from '../../src/types/types';
 import assert from '../../src/utils/assertExtra';
+import logger from '../../src/utils/log';
 
 const readFile = promisify(readFileCallback);
+const writeFile = promisify(writeFileCallback);
+
+// If the tests are failing, examine the diff.
+// If it looks correct, set UPDATE_FILES to true and re-run the integration tests
+// Check the contents of the files, and re-set UPDATE_FILES to false before committing.
+const UPDATE_FILES = false;
 
 describe('src/combiner', () => {
   let resultsBySourceFileAndFunction: { [sourceFilePath: string]: { [testedFunction: string]: AnalysisResult[] }};
@@ -17,9 +24,14 @@ describe('src/combiner', () => {
   let expectedFirstTestClass: string;
   let expectedMergedTestClass: string;
 
-  const sampleSourceFilePath = '/com/diffblue/javademo/UserAccess.java';
+  const sampleSourceFilePath = 'com/diffblue/javademo/UserAccess.java';
   const sampleSingleTestFunction = 'java::com.diffblue.javademo.UserAccess.getCurrentUser:()Ljava/lang/String;';
   const sampleMultiTestFunction = 'java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z'; // tslint:disable-line:max-line-length
+
+  const expectedSingleTestClassPath = './tests/integration/fixtures/combiner/ExpectedSingleTestClass.java';
+  const expectedMultiTestClassPath = './tests/integration/fixtures/combiner/ExpectedMultiTestClass.java';
+  const expectedFirstTestClassPath = './tests/integration/fixtures/combiner/ExpectedFirstTestClass.java';
+  const expectedMergedTestClassPath = './tests/integration/fixtures/combiner/ExpectedMergedTestClass.java';
 
   before('', async () => {
     const resultsJson = await readFile('./tests/integration/fixtures/sample-java-demo-results.json');
@@ -30,38 +42,64 @@ describe('src/combiner', () => {
     });
 
     expectedSingleTestClass = (
-      await readFile('./tests/integration/fixtures/combiner/ExpectedSingleTestClass.java')
+      await readFile(expectedSingleTestClassPath)
     ).toString();
     expectedMultiTestClass = (
-      await readFile('./tests/integration/fixtures/combiner/ExpectedMultiTestClass.java')
+      await readFile(expectedMultiTestClassPath)
     ).toString();
     expectedFirstTestClass = (
-      await readFile('./tests/integration/fixtures/combiner/ExpectedFirstTestClass.java')
+      await readFile(expectedFirstTestClassPath)
     ).toString();
     expectedMergedTestClass = (
-      await readFile('./tests/integration/fixtures/combiner/ExpectedMergedTestClass.java')
+      await readFile(expectedMergedTestClassPath)
     ).toString();
   });
 
   describe('generateTestClass', () => {
     it('Check fixtures', () => {
-      assert.ok(sampleSourceFilePath in resultsBySourceFileAndFunction);
-      assert.ok(sampleSingleTestFunction in resultsBySourceFileAndFunction[sampleSourceFilePath]);
-      assert.ok(resultsBySourceFileAndFunction[sampleSourceFilePath][sampleSingleTestFunction].length === 1);
-      assert.ok(sampleMultiTestFunction in resultsBySourceFileAndFunction[sampleSourceFilePath]);
-      assert.ok(resultsBySourceFileAndFunction[sampleSourceFilePath][sampleMultiTestFunction].length > 1);
+      assert.ok(
+        sampleSourceFilePath in resultsBySourceFileAndFunction,
+        `${sampleSourceFilePath} not found`,
+      );
+      assert.ok(
+        sampleSingleTestFunction in resultsBySourceFileAndFunction[sampleSourceFilePath],
+        `${sampleSingleTestFunction} not found`,
+      );
+      assert.ok(
+        resultsBySourceFileAndFunction[sampleSourceFilePath][sampleSingleTestFunction].length === 1,
+        'Too many tests for sampleSingleTestFunction',
+      );
+      assert.ok(
+        sampleMultiTestFunction in resultsBySourceFileAndFunction[sampleSourceFilePath],
+        `${sampleMultiTestFunction} not found`,
+      );
+      assert.ok(
+        resultsBySourceFileAndFunction[sampleSourceFilePath][sampleMultiTestFunction].length > 1,
+        'Not enough tests for sampleMultiTestFunction',
+      );
+      assert.ok(!UPDATE_FILES, 'UPDATE_FILES must be false for the integration tests to pass.');
     });
 
-    it('Can generate a test class for a single test', () => {
+    it('Can generate a test class for a single test', async () => {
       const results = resultsBySourceFileAndFunction[sampleSourceFilePath][sampleSingleTestFunction];
       const testClass = generateTestClass(results);
-      assert.strictEqual(testClass, expectedSingleTestClass);
+      if (UPDATE_FILES) {
+        logger.log(`Updating ${expectedSingleTestClassPath}`);
+        await writeFile(expectedSingleTestClassPath, testClass);
+      } else {
+        assert.strictEqual(testClass, expectedSingleTestClass);
+      }
     });
 
-    it('Can generate a test class for multiple tests (including class annotations)', () => {
+    it('Can generate a test class for multiple tests (including class annotations)', async () => {
       const results = resultsBySourceFileAndFunction[sampleSourceFilePath][sampleMultiTestFunction];
       const testClass = generateTestClass(results);
-      assert.strictEqual(testClass, expectedMultiTestClass);
+      if (UPDATE_FILES) {
+        logger.log(`Updating ${expectedMultiTestClassPath}`);
+        await writeFile(expectedMultiTestClassPath, testClass);
+      } else {
+        assert.strictEqual(testClass, expectedMultiTestClass);
+      }
     });
   });
 
@@ -72,9 +110,19 @@ describe('src/combiner', () => {
         ...results
       ] = resultsBySourceFileAndFunction[sampleSourceFilePath][sampleMultiTestFunction];
       const testClass = generateTestClass([firstResult]);
-      assert.strictEqual(testClass, expectedFirstTestClass);
+      if (UPDATE_FILES) {
+        logger.log(`Updating ${expectedFirstTestClassPath}`);
+        await writeFile(expectedFirstTestClassPath, testClass);
+      } else {
+        assert.strictEqual(testClass, expectedFirstTestClass);
+      }
       const mergedTestClass = await mergeIntoTestClass(testClass, results);
-      assert.strictEqual(mergedTestClass, expectedMergedTestClass);
+      if (UPDATE_FILES) {
+        logger.log(`Updating ${expectedMergedTestClassPath}`);
+        await writeFile(expectedMergedTestClassPath, mergedTestClass);
+      } else {
+        assert.strictEqual(mergedTestClass, expectedMergedTestClass);
+      }
     });
   });
 });

--- a/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
@@ -1,42 +1,72 @@
 package com.diffblue.javademo;
 
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
+
+import com.diffblue.deeptestutils.Reflector;
+import com.diffblue.deeptestutils.mock.DTUMemberMatcher;
 import com.diffblue.javademo.UserAccess;
+import com.diffblue.javademo.serveraccess.DatabaseDao;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 
 
+@RunWith(PowerMockRunner.class)
 public class UserAccess {
 
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public final Timeout globalTimeout = new Timeout(10000);
-
-  /* testedClasses: UserAccessTest */
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 25
-   */
-
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNullOutputFalse() {
+  public void loginUserInputNotNullNotNullOutputFalse() throws Exception, InvocationTargetException {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "";
-    final String password = null;
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
 
     // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
 
     // Assert result
-    Assert.assertEquals(false, retval);
+    Assert.assertFalse(actual);
 
   }
+
 }

--- a/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
@@ -32,6 +32,9 @@ import java.lang.reflect.Method;
 @RunWith(PowerMockRunner.class)
 public class UserAccess {
 
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
+
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test

--- a/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
@@ -1,12 +1,5 @@
 package com.diffblue.javademo;
 
-import com.diffblue.javademo.UserAccess;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
-
 import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.isA;
@@ -14,12 +7,18 @@ import static org.mockito.Matchers.isNull;
 
 import com.diffblue.deeptestutils.Reflector;
 import com.diffblue.deeptestutils.mock.DTUMemberMatcher;
+import com.diffblue.javademo.UserAccess;
 import com.diffblue.javademo.serveraccess.DatabaseDao;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -33,57 +32,21 @@ import java.lang.reflect.Method;
 @RunWith(PowerMockRunner.class)
 public class UserAccess {
 
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public final Timeout globalTimeout = new Timeout(10000);
-
-  /* testedClasses: UserAccessTest */
-
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 25
-   */
-
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse2() {
-
-    // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = "";
-
-    // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
-
-    // Assert result
-    Assert.assertEquals(false, retval);
-
-  }
-
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 28
-   *  - conditional line 33 branch to line 38
-   */
+  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
   public void loginUserInputNotNullNotNullOutputFalse() throws Exception, InvocationTargetException {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = " ";
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
     final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
     final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(2_147_483_649L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
     final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
     PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
     final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
@@ -96,73 +59,411 @@ public class UserAccess {
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
 
     // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
-
-    // Assert result
-    Assert.assertEquals(false, retval);
-
-  }
-
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 28
-   *  - conditional line 33 branch to line 34
-   */
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputTrue() throws Exception, InvocationTargetException {
-
-    // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = " ";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
+    final boolean actual = userAccess.loginUser(username, password);
 
     // Assert side effects
-    Assert.assertEquals("AAAAAAAA", objectUnderTest.getCurrentUser());
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
 
     // Assert result
-    Assert.assertEquals(true, retval);
+    Assert.assertFalse(actual);
 
   }
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 25
-   */
 
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse1010() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse99() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse8003dfeaa8b9e2c344a4() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse7002c69a479635c59106() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "?"));
+
+  }
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse60009bd811bb64afa0a6() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse55() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse44() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "??"));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse33() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse22() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue55() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue40011283edb7e0d812f2() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue33() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue22() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "??";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue0011fd6a71b0dfbd0fb() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
   @Test
   public void loginUserInputNotNullNullOutputFalse() {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "";
-    final String password = null;
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
 
-    // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
-
-    // Assert result
-    Assert.assertEquals(false, retval);
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", null));
 
   }
 }

--- a/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
@@ -32,6 +32,9 @@ import java.lang.reflect.Method;
 @RunWith(PowerMockRunner.class)
 public class UserAccess {
 
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
+
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
@@ -72,115 +75,7 @@ public class UserAccess {
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputFalse1010() throws Exception {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-    final String username = "?";
-    final String password = "?";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean actual = userAccess.loginUser(username, password);
-
-    // Assert side effects
-    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
-
-    // Assert result
-    Assert.assertFalse(actual);
-
-  }
-
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse99() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("?", ""));
-
-  }
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse8003dfeaa8b9e2c344a4() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", "");
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
-
-  }
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse7002c69a479635c59106() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", "");
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("", "?"));
-
-  }
-  // Test written by Diffblue Cover.
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse60009bd811bb64afa0a6() throws Exception {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-    final String username = "?";
-    final String password = "?";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean actual = userAccess.loginUser(username, password);
-
-    // Assert side effects
-    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
-
-    // Assert result
-    Assert.assertFalse(actual);
-
-  }
-
-  // Test written by Diffblue Cover.
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse55() throws Exception {
+  public void loginUserInputNotNullNotNullOutputFalse105() throws Exception {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
@@ -214,31 +109,9 @@ public class UserAccess {
   }
 
   // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse44() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("", "??"));
-
-  }
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse33() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("?", ""));
-
-  }
-  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputFalse22() throws Exception, InvocationTargetException {
+  public void loginUserInputNotNullNotNullOutputFalse92() throws Exception, InvocationTargetException {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
@@ -275,7 +148,137 @@ public class UserAccess {
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputTrue55() throws Exception {
+  public void loginUserInputNotNullNotNullOutputFalse80009bd811bb64afa0a6() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse79() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse63() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse510() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Bson.class), org.mockito.Matchers.isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse4002c69a479635c59106() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "?"));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse3003dfeaa8b9e2c344a4() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
+
+  }
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse24() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "??"));
+
+  }
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue50011283edb7e0d812f2() throws Exception {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
@@ -311,13 +314,13 @@ public class UserAccess {
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputTrue40011283edb7e0d812f2() throws Exception {
+  public void loginUserInputNotNullNotNullOutputTrue40011fd6a71b0dfbd0fb() throws Exception, InvocationTargetException {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
     Reflector.setField(userAccess, "currentUser", null);
-    final String username = "?";
-    final String password = "?";
+    final String username = "foo";
+    final String password = "foo";
     final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
@@ -329,8 +332,9 @@ public class UserAccess {
     PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
     PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
     final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
     final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
 
     // Act
@@ -420,13 +424,13 @@ public class UserAccess {
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputTrue0011fd6a71b0dfbd0fb() throws Exception, InvocationTargetException {
+  public void loginUserInputNotNullNotNullOutputTrue5() throws Exception {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
     Reflector.setField(userAccess, "currentUser", null);
-    final String username = "foo";
-    final String password = "foo";
+    final String username = "?";
+    final String password = "?";
     final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
@@ -438,9 +442,8 @@ public class UserAccess {
     PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));
     PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);
     final Document document = PowerMockito.mock(Document.class);
-    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
     final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);
 
     // Act

--- a/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
@@ -32,73 +32,66 @@ import java.lang.reflect.Method;
 @RunWith(PowerMockRunner.class)
 public class UserAccess {
 
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public final Timeout globalTimeout = new Timeout(10000);
-
-  /* testedClasses: UserAccessTest */
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 25
-   */
-
-  @Test
-  public void loginUserInputNotNullNullOutputFalse() {
-
-    // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "";
-    final String password = null;
-
-    // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
-
-    // Assert result
-    Assert.assertEquals(false, retval);
-
-  }
-
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 25
-   */
-
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse() {
-
-    // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = "";
-
-    // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
-
-    // Assert result
-    Assert.assertEquals(false, retval);
-
-  }
-
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 28
-   *  - conditional line 33 branch to line 34
-   */
+  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputTrue() throws Exception, InvocationTargetException {
+  public void loginUserInputNotNullNotNullOutputFalse2() throws Exception, InvocationTargetException {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = " ";
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse3() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue2() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "??";
     final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
@@ -116,36 +109,44 @@ public class UserAccess {
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
 
     // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
+    final boolean actual = userAccess.loginUser(username, password);
 
     // Assert side effects
-    Assert.assertEquals("AAAAAAAA", objectUnderTest.getCurrentUser());
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
 
     // Assert result
-    Assert.assertEquals(true, retval);
+    Assert.assertTrue(actual);
 
   }
 
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers:
-   *  - conditional line 24 branch to line 24
-   *  - conditional line 24 branch to line 28
-   *  - conditional line 33 branch to line 38
-   */
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+
+  // Test written by Diffblue Cover.
   @Test
-  public void loginUserInputNotNullNotNullOutputFalse2() throws Exception, InvocationTargetException {
+  public void loginUserInputNotNullNotNullOutputFalse4() {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
-    final String username = "AAAAAAAA";
-    final String password = " ";
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "??"));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse3() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
     final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
     final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(2_147_483_649L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
     final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
     PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
     final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
@@ -158,10 +159,326 @@ public class UserAccess {
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
 
     // Act
-    final boolean retval = objectUnderTest.loginUser(username, password);
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
 
     // Assert result
-    Assert.assertEquals(false, retval);
+    Assert.assertFalse(actual);
 
   }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue1() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse5() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue3() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse5() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue3() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse6() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "?"));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse7() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNullOutputFalse() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", null));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse9() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("?", ""));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse10() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertFalse(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue5() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
 }

--- a/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
@@ -32,6 +32,9 @@ import java.lang.reflect.Method;
 @RunWith(PowerMockRunner.class)
 public class UserAccess {
 
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
+
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
@@ -83,6 +86,18 @@ public class UserAccess {
   }
 
   // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse4() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "??"));
+
+  }
+
+  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
   public void loginUserInputNotNullNotNullOutputTrue2() throws Exception, InvocationTargetException {
@@ -121,94 +136,6 @@ public class UserAccess {
 
 
   // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse4() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("", "??"));
-
-  }
-
-  // Test written by Diffblue Cover.
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse3() throws Exception, InvocationTargetException {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-    final String username = "foo";
-    final String password = "foo";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean actual = userAccess.loginUser(username, password);
-
-    // Assert side effects
-    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
-
-    // Assert result
-    Assert.assertFalse(actual);
-
-  }
-
-
-  // Test written by Diffblue Cover.
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputTrue1() throws Exception, InvocationTargetException {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-    final String username = "foo";
-    final String password = "foo";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean actual = userAccess.loginUser(username, password);
-
-    // Assert side effects
-    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
-
-    // Assert result
-    Assert.assertTrue(actual);
-
-  }
-
-
-  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
   public void loginUserInputNotNullNotNullOutputFalse5() throws Exception {
@@ -248,7 +175,7 @@ public class UserAccess {
   // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
-  public void loginUserInputNotNullNotNullOutputTrue3() throws Exception {
+  public void loginUserInputNotNullNotNullOutputFalse4() throws Exception, InvocationTargetException {
 
     // Arrange
     final UserAccess userAccess = new UserAccess();
@@ -259,15 +186,16 @@ public class UserAccess {
     final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
     final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
     final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
     final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
     PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
     final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
     PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
     PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
     final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
     final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
     PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
 
     // Act
@@ -277,7 +205,7 @@ public class UserAccess {
     Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
 
     // Assert result
-    Assert.assertTrue(actual);
+    Assert.assertFalse(actual);
 
   }
 
@@ -318,82 +246,6 @@ public class UserAccess {
 
   }
 
-
-  // Test written by Diffblue Cover.
-  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
-  @Test
-  public void loginUserInputNotNullNotNullOutputTrue3() throws Exception {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-    final String username = "?";
-    final String password = "?";
-    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
-    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
-    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
-    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
-    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
-    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
-    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
-    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
-    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
-    final Document document = PowerMockito.mock(Document.class);
-    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
-    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
-    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
-
-    // Act
-    final boolean actual = userAccess.loginUser(username, password);
-
-    // Assert side effects
-    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
-
-    // Assert result
-    Assert.assertTrue(actual);
-
-  }
-
-
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse6() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", "");
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("", "?"));
-
-  }
-
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNotNullOutputFalse7() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", "");
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
-
-  }
-
-  // Test written by Diffblue Cover.
-  @Test
-  public void loginUserInputNotNullNullOutputFalse() {
-
-    // Arrange
-    final UserAccess userAccess = new UserAccess();
-    Reflector.setField(userAccess, "currentUser", null);
-
-    // Act and Assert result
-    Assert.assertFalse(userAccess.loginUser("", null));
-
-  }
 
   // Test written by Diffblue Cover.
   @Test
@@ -446,6 +298,144 @@ public class UserAccess {
 
 
   // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse8() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", "?"));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNotNullOutputFalse9() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", "");
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("????????????????", ""));
+
+  }
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue1() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "?";
+    final String password = "?";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue2() throws Exception, InvocationTargetException {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Document document1 = (Document) Reflector.getInstance("org.bson.Document");
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
+  @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
+  @Test
+  public void loginUserInputNotNullNotNullOutputTrue3() throws Exception {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+    final String username = "foo";
+    final String password = "foo";
+    final MongoClient mongoClient = PowerMockito.mock(MongoClient.class);
+    final MongoDatabase mongoDatabase = PowerMockito.mock(MongoDatabase.class);
+    final MongoCollection mongoCollection = PowerMockito.mock(MongoCollection.class);
+    final Method countMethod = DTUMemberMatcher.method(MongoCollection.class, "count", Bson.class);
+    PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(or(isA(Bson.class), isNull(Bson.class)));
+    final Method getCollectionMethod = DTUMemberMatcher.method(MongoDatabase.class, "getCollection", String.class);
+    PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    final Method getDatabaseMethod = DTUMemberMatcher.method(MongoClient.class, "getDatabase", String.class);
+    PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(or(isA(String.class), isNull(String.class)));
+    PowerMockito.whenNew(MongoClient.class).withParameterTypes(String.class, int.class).withArguments(or(isA(String.class), isNull(String.class)), anyInt()).thenReturn(mongoClient);
+    final Document document = PowerMockito.mock(Document.class);
+    final Method appendMethod = DTUMemberMatcher.method(Document.class, "append", String.class, Object.class);
+    PowerMockito.doReturn(null).when(document, appendMethod).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class)));
+    PowerMockito.whenNew(Document.class).withParameterTypes(String.class, Object.class).withArguments(or(isA(String.class), isNull(String.class)), or(isA(Object.class), isNull(Object.class))).thenReturn(document);
+
+    // Act
+    final boolean actual = userAccess.loginUser(username, password);
+
+    // Assert side effects
+    Assert.assertNotNull(Reflector.getInstanceField(DatabaseDao.class, null, "instance"));
+
+    // Assert result
+    Assert.assertTrue(actual);
+
+  }
+
+
+  // Test written by Diffblue Cover.
   @PrepareForTest({MongoDatabase.class, UserAccess.class, MongoCollection.class, Document.class, MongoClient.class, DatabaseDao.class})
   @Test
   public void loginUserInputNotNullNotNullOutputTrue5() throws Exception {
@@ -481,4 +471,17 @@ public class UserAccess {
 
   }
 
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void loginUserInputNotNullNullOutputFalse() {
+
+    // Arrange
+    final UserAccess userAccess = new UserAccess();
+    Reflector.setField(userAccess, "currentUser", null);
+
+    // Act and Assert result
+    Assert.assertFalse(userAccess.loginUser("", null));
+
+  }
 }

--- a/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
@@ -11,29 +11,15 @@ import org.junit.rules.Timeout;
 
 public class UserAccess {
 
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public final Timeout globalTimeout = new Timeout(10000);
-
-  /* testedClasses: UserAccessTest */
-  /*
-   * Test written by Diffblue Cover.
-   * This test case covers the entire method.
-   */
-
+  // Test written by Diffblue Cover.
   @Test
   public void getCurrentUserOutputNull() {
 
     // Arrange
-    final UserAccess objectUnderTest = new UserAccess();
+    final UserAccess userAccess = new UserAccess();
 
-    // Act
-    final String retval = objectUnderTest.getCurrentUser();
-
-    // Assert result
-    Assert.assertNull(retval);
+    // Act and Assert result
+    Assert.assertNull(userAccess.getCurrentUser());
 
   }
 }

--- a/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
@@ -11,6 +11,9 @@ import org.junit.rules.Timeout;
 
 public class UserAccess {
 
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
+
   // Test written by Diffblue Cover.
   @Test
   public void getCurrentUserOutputNull() {

--- a/tests/integration/fixtures/sample-java-demo-results.json
+++ b/tests/integration/fixtures/sample-java-demo-results.json
@@ -1,684 +1,2754 @@
 {
-    "results": [
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638431939,
-            "testId": "hasItemOutputFalse000002478500056a72c",
-            "testName": "hasItemOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Order.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 12 branch to line 13\n */\n\n@org.junit.Test\npublic void hasItemOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act\n  final boolean retval = objectUnderTest.hasItem();\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638432009,
-            "testId": "hasItemOutputTrue001289396b6ed133fd6",
-            "testName": "hasItemOutputTrue",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Order.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 12 branch to line 15\n */\n\n@org.junit.Test\npublic void hasItemOutputTrue() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  objectUnderTest.setItem(item);\n\n  // Act\n  final boolean retval = objectUnderTest.hasItem();\n\n  // Assert result\n  Assert.assertEquals(true, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638437531,
-            "testId": "constructorOutputVoid000f4eb42f706b62ec2",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Order.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.subpackage.Order objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638441494,
-            "testId": "setItemInputNullOutputFalse0002b3fd0a1432d7acb",
-            "testName": "setItemInputNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Order.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void setItemInputNullOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = null;\n\n  // Act\n  final boolean retval = objectUnderTest.setItem(item);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638445957,
-            "testId": "getItemOutputNull000fb3c915799377f38",
-            "testName": "getItemOutputNull",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.getItem:()Lcom/diffblue/javademo/nestedobjects/subpackage/Item;",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Order.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void getItemOutputNull() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.subpackage.Item retval = objectUnderTest.getItem();\n\n  // Assert result\n  Assert.assertNull(retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638450142,
-            "testId": "constructorOutputVoid00007d76d2c63dba6f1",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Item.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/subpackage/Item.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.subpackage.Item objectUnderTest = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.Search",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638454975,
-            "testId": "constructorOutputVoid000a0d75135ed099cc4",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.Search.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.Search",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638459660,
-            "testId": "containsInput1ZeroOutputTrue002ea108cd4cf6cca1c",
-            "testName": "containsInput1ZeroOutputTrue",
-            "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - com/diffblue/javademo/Search.java:14: loop: 1 iterations\n *  - iteration 1\n *     - conditional line 15 branch to line 16\n */\n\n@org.junit.Test\npublic void containsInput1ZeroOutputTrue() {\n\n  // Arrange\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n  final int[] array = { 0 };\n  final int target = 0;\n\n  // Act\n  final boolean retval = objectUnderTest.contains(array, target);\n\n  // Assert result\n  Assert.assertEquals(true, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.Search",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638459661,
-            "testId": "containsInput1ZeroOutputFalse0014ef82084290a8e5e",
-            "testName": "containsInput1ZeroOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - com/diffblue/javademo/Search.java:14: loop: 1 iterations\n *  - iteration 1\n *     - conditional line 15 branch to line 14\n */\n\n@org.junit.Test\npublic void containsInput1ZeroOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n  final int[] array = { 1 };\n  final int target = 0;\n\n  // Act\n  final boolean retval = objectUnderTest.contains(array, target);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.Search",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638459669,
-            "testId": "containsInput0ZeroOutputFalse000f017e78343ab0a66",
-            "testName": "containsInput0ZeroOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *\n */\n\n@org.junit.Test\npublic void containsInput0ZeroOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n  final int[] array = { };\n  final int target = 0;\n\n  // Act\n  final boolean retval = objectUnderTest.contains(array, target);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.Search",
-                "org.apache.commons.codec.digest.DigestUtils",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull",
-                "org.powermock.api.mockito.PowerMockito.mockStatic"
-            ],
-            "createdTime": 1556638467064,
-            "testId": "isNeedleInHaystackInputNullOutputFalse000486ec3594ccc3dc0",
-            "testName": "isNeedleInHaystackInputNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 30 branch to line 33\n */\n@org.powermock.core.classloader.annotations.PrepareForTest(org.apache.commons.codec.digest.DigestUtils.class)\n@org.junit.Test\npublic void isNeedleInHaystackInputNullOutputFalse() throws Exception {\n\n  // Setup mocks\n  org.powermock.api.mockito.PowerMockito.mockStatic(org.apache.commons.codec.digest.DigestUtils.class);\n\n  // Arrange\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n  final String input = null;\n  final java.lang.reflect.Method sha1HexMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.apache.commons.codec.digest.DigestUtils.class, \"sha1Hex\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(org.apache.commons.codec.digest.DigestUtils.class, sha1HexMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n\n  // Act\n  final boolean retval = objectUnderTest.isNeedleInHaystack(input);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638474620,
-            "testId": "constructorInputNullOutputVoid0000cae24d076e02b0e",
-            "testName": "constructorInputNullOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorInputNullOutputVoid() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = null;\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = new com.diffblue.javademo.nestedobjects.User(order);\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638477973,
-            "testId": "checkItemCostInputNullOutputFalse00095fd0fb4c2c6b984",
-            "testName": "checkItemCostInputNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 17 branch to line 18\n */\n\n@org.junit.Test\npublic void checkItemCostInputNullOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = new com.diffblue.javademo.nestedobjects.User(order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = null;\n\n  // Act\n  final boolean retval = objectUnderTest.checkItemCost(item);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.InvocationTargetException",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638478538,
-            "testId": "checkItemCostInputNotNullOutputFalse0014f9ae45868175501",
-            "testName": "checkItemCostInputNotNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 17 branch to line 20\n *  - conditional line 20 branch to line 20\n */\n\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputFalse() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = -2_147_483_648;\n  order.item = item1;\n  Reflector.setField(objectUnderTest, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Act\n  final boolean retval = objectUnderTest.checkItemCost(item);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Item",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638478650,
-            "testId": "checkItemCostInputNotNullOutputTrue0024322453be5334ead",
-            "testName": "checkItemCostInputNotNullOutputTrue",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 17 branch to line 20\n *  - conditional line 20 branch to line 20\n */\n\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputTrue() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = new com.diffblue.javademo.nestedobjects.User(null);\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  order.setItem(item1);\n  objectUnderTest.setOrder(order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Act\n  final boolean retval = objectUnderTest.checkItemCost(item);\n\n  // Assert result\n  Assert.assertEquals(true, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638482504,
-            "testId": "setOrderInputNullOutputNotNull00021be91177d2cbd66",
-            "testName": "setOrderInputNullOutputNotNull",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void setOrderInputNullOutputNotNull() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = new com.diffblue.javademo.nestedobjects.User(null);\n  final com.diffblue.javademo.nestedobjects.subpackage.Order newOrder = null;\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.User retval = objectUnderTest.setOrder(newOrder);\n\n  // Assert result\n  Assert.assertNotNull(retval);\n  Assert.assertNull(retval.getOrder());\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.nestedobjects.User",
-                "com.diffblue.javademo.nestedobjects.subpackage.Order",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638486006,
-            "testId": "getOrderOutputNull00060c54410d284c396",
-            "testName": "getOrderOutputNull",
-            "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.getOrder:()Lcom/diffblue/javademo/nestedobjects/subpackage/Order;",
-            "sourceFilePath": "/com/diffblue/javademo/nestedobjects/User.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void getOrderOutputNull() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User objectUnderTest = new com.diffblue.javademo.nestedobjects.User(null);\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.subpackage.Order retval = objectUnderTest.getOrder();\n\n  // Assert result\n  Assert.assertNull(retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.TicTacToe",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638489533,
-            "testId": "constructorOutputVoid000b6c1a18bb55bbd78",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.TicTacToe.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/TicTacToe.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.TicTacToe objectUnderTest = new com.diffblue.javademo.TicTacToe();\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.TicTacToe",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638493011,
-            "testId": "checkTicTacToePositionInput0OutputIllegalArgumentException000000b84d103fc4807",
-            "testName": "checkTicTacToePositionInput0OutputIllegalArgumentException",
-            "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
-            "sourceFilePath": "/com/diffblue/javademo/TicTacToe.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 20 branch to line 21\n */\n\n@org.junit.Test\npublic void checkTicTacToePositionInput0OutputIllegalArgumentException() {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe objectUnderTest = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  objectUnderTest.checkTicTacToePosition(board);\n\n  // Method is not expected to return due to exception thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "com.mongodb.MongoClient",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.anyInt",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull"
-            ],
-            "createdTime": 1556638496790,
-            "testId": "getInstanceOutputNotNull000a66866087714bceb",
-            "testName": "getInstanceOutputNotNull",
-            "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getInstance:()Lcom/diffblue/javademo/serveraccess/DatabaseDao;",
-            "sourceFilePath": "/com/diffblue/javademo/serveraccess/DatabaseDao.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 29 branch to line 30\n */\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void getInstanceOutputNotNull() throws Exception {\n\n  // Arrange\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n\n  // Act\n  final com.diffblue.javademo.serveraccess.DatabaseDao retval = com.diffblue.javademo.serveraccess.DatabaseDao.getInstance();\n\n  // Assert result\n  Assert.assertNotNull(retval);\n  Assert.assertEquals(27_017, Reflector.getInstanceField(retval, \"port\"));\n  Assert.assertEquals(\"localhost\", Reflector.getInstanceField(retval, \"hostname\"));\n  Assert.assertEquals(\"java-demo\", Reflector.getInstanceField(retval, \"dbName\"));\n  Assert.assertNull(Reflector.getInstanceField(retval, \"mongoDatabase\"));\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.InvocationTargetException",
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "com.mongodb.client.MongoCollection",
-                "com.mongodb.client.MongoDatabase",
-                "org.bson.Document",
-                "org.bson.conversions.Bson",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull"
-            ],
-            "createdTime": 1556638504501,
-            "testId": "getCountFromDbInputNullNullOutputZero000cf32365ba2cce347",
-            "testName": "getCountFromDbInputNullNullOutputZero",
-            "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getCountFromDb:(Ljava/lang/String;Lorg/bson/Document;)I",
-            "sourceFilePath": "/com/diffblue/javademo/serveraccess/DatabaseDao.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoCollection.class, com.mongodb.client.MongoDatabase.class})\n@org.junit.Test\npublic void getCountFromDbInputNullNullOutputZero() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.serveraccess.DatabaseDao objectUnderTest = (com.diffblue.javademo.serveraccess.DatabaseDao) Reflector.getInstance(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  Reflector.setField(objectUnderTest, \"port\", 0);\n  Reflector.setField(objectUnderTest, \"hostname\", null);\n  Reflector.setField(objectUnderTest, \"dbName\", null);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  Reflector.setField(objectUnderTest, \"mongoDatabase\", mongoDatabase);\n  final String collectionName = null;\n  final org.bson.Document searchFor = null;\n\n  // Act\n  final int retval = objectUnderTest.getCountFromDb(collectionName, searchFor);\n\n  // Assert result\n  Assert.assertEquals(0, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Constructor",
-                "java.lang.reflect.InvocationTargetException",
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638511166,
-            "testId": "constructorOutputVoid0003d004d67d17982fa",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/serveraccess/DatabaseDao.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() throws java.lang.reflect.InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {\n\n  // Act, creating object to test constructor\n  final Class<?> classUnderTest = Reflector.forName(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  final Constructor<?> ctor = classUnderTest.getDeclaredConstructor();\n  ctor.setAccessible(true);\n  final com.diffblue.javademo.serveraccess.DatabaseDao objectUnderTest = (com.diffblue.javademo.serveraccess.DatabaseDao) ctor.newInstance();\n\n  // Assert side effects\n  Assert.assertEquals(27_017, Reflector.getInstanceField(objectUnderTest, \"port\"));\n  Assert.assertEquals(\"localhost\", Reflector.getInstanceField(objectUnderTest, \"hostname\"));\n  Assert.assertEquals(\"java-demo\", Reflector.getInstanceField(objectUnderTest, \"dbName\"));\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.InvocationTargetException",
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "com.mongodb.MongoClient",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.anyInt",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull"
-            ],
-            "createdTime": 1556638515098,
-            "testId": "connectToDbOutputVoid0000a4f6501193d3ac3",
-            "testName": "connectToDbOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.connectToDb:()V",
-            "sourceFilePath": "/com/diffblue/javademo/serveraccess/DatabaseDao.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void connectToDbOutputVoid() throws Exception, java.lang.reflect.InvocationTargetException, IllegalAccessException, NoSuchMethodException {\n\n  // Arrange\n  final com.diffblue.javademo.serveraccess.DatabaseDao objectUnderTest = (com.diffblue.javademo.serveraccess.DatabaseDao) Reflector.getInstance(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  Reflector.setField(objectUnderTest, \"port\", 0);\n  Reflector.setField(objectUnderTest, \"hostname\", null);\n  Reflector.setField(objectUnderTest, \"dbName\", null);\n  Reflector.setField(objectUnderTest, \"mongoDatabase\", null);\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n\n  // Act\n  final Class<?> classUnderTest = Reflector.forName(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  final Method methodUnderTest = classUnderTest.getDeclaredMethod(\"connectToDb\");\n  methodUnderTest.setAccessible(true);\n  methodUnderTest.invoke(objectUnderTest);\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.javademo.UserAccess",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638522340,
-            "testId": "constructorOutputVoid0009186e4ac27552e24",
-            "testName": "constructorOutputVoid",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.<init>:()V",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void constructorOutputVoid() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n\n  // Method returns void, testing that no exception is thrown\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.UserAccess",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638526394,
-            "testId": "getCurrentUserOutputNull000b4e0faa6d7896e93",
-            "testName": "getCurrentUserOutputNull",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.getCurrentUser:()Ljava/lang/String;",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers the entire method.\n */\n\n@org.junit.Test\npublic void getCurrentUserOutputNull() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n\n  // Act\n  final String retval = objectUnderTest.getCurrentUser();\n\n  // Assert result\n  Assert.assertNull(retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.UserAccess",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638531959,
-            "testId": "loginUserInputNotNullNullOutputFalse000aa7960cd86920e28",
-            "testName": "loginUserInputNotNullNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 24 branch to line 25\n */\n\n@org.junit.Test\npublic void loginUserInputNotNullNullOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n  final String username = \"\";\n  final String password = null;\n\n  // Act\n  final boolean retval = objectUnderTest.loginUser(username, password);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [],
-            "imports": [
-                "com.diffblue.javademo.UserAccess",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException"
-            ],
-            "staticImports": [],
-            "createdTime": 1556638532221,
-            "testId": "loginUserInputNotNullNotNullOutputFalse0017cfc693b609533d5",
-            "testName": "loginUserInputNotNullNotNullOutputFalse",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 24 branch to line 24\n *  - conditional line 24 branch to line 25\n */\n\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n  final String username = \"AAAAAAAA\";\n  final String password = \"\";\n\n  // Act\n  final boolean retval = objectUnderTest.loginUser(username, password);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.InvocationTargetException",
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.UserAccess",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "com.mongodb.MongoClient",
-                "com.mongodb.client.MongoCollection",
-                "com.mongodb.client.MongoDatabase",
-                "org.bson.Document",
-                "org.bson.conversions.Bson",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.anyInt",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull"
-            ],
-            "createdTime": 1556638532862,
-            "testId": "loginUserInputNotNullNotNullOutputTrue00268ab6e8656faabec",
-            "testName": "loginUserInputNotNullNotNullOutputTrue",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 24 branch to line 24\n *  - conditional line 24 branch to line 28\n *  - conditional line 33 branch to line 34\n */\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n  final String username = \"AAAAAAAA\";\n  final String password = \" \";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean retval = objectUnderTest.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertEquals(\"AAAAAAAA\", objectUnderTest.getCurrentUser());\n\n  // Assert result\n  Assert.assertEquals(true, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.InvocationTargetException",
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.Reflector",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.UserAccess",
-                "com.diffblue.javademo.serveraccess.DatabaseDao",
-                "com.mongodb.MongoClient",
-                "com.mongodb.client.MongoCollection",
-                "com.mongodb.client.MongoDatabase",
-                "org.bson.Document",
-                "org.bson.conversions.Bson",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.anyInt",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull"
-            ],
-            "createdTime": 1556638532864,
-            "testId": "loginUserInputNotNullNotNullOutputFalse0037880985dcffb03f6",
-            "testName": "loginUserInputNotNullNotNullOutputFalse2",
-            "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/UserAccess.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 24 branch to line 24\n *  - conditional line 24 branch to line 28\n *  - conditional line 33 branch to line 38\n */\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse2() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess objectUnderTest = new com.diffblue.javademo.UserAccess();\n  final String username = \"AAAAAAAA\";\n  final String password = \" \";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(2_147_483_649L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean retval = objectUnderTest.loginUser(username, password);\n\n  // Assert result\n  Assert.assertEquals(false, retval);\n\n}",
-            "tags": []
-        },
-        {
-            "classAnnotations": [
-                "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
-            ],
-            "imports": [
-                "java.lang.reflect.Method",
-                "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
-                "com.diffblue.javademo.Search",
-                "org.apache.commons.codec.digest.DigestUtils",
-                "org.junit.Assert",
-                "org.junit.Rule",
-                "org.junit.Test",
-                "org.junit.rules.ExpectedException",
-                "org.junit.runner.RunWith",
-                "org.powermock.api.mockito.PowerMockito",
-                "org.powermock.core.classloader.annotations.PrepareForTest",
-                "org.powermock.modules.junit4.PowerMockRunner"
-            ],
-            "staticImports": [
-                "org.mockito.AdditionalMatchers.or",
-                "org.mockito.Matchers.isA",
-                "org.mockito.Matchers.isNull",
-                "org.powermock.api.mockito.PowerMockito.mockStatic"
-            ],
-            "createdTime": 1556638545549,
-            "testId": "isNeedleInHaystackInputNullOutputTrue000adff201b946ea792",
-            "testName": "isNeedleInHaystackInputNullOutputTrue",
-            "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
-            "sourceFilePath": "/com/diffblue/javademo/Search.java",
-            "testBody": "/*\n * Test written by Diffblue Cover.\n * This test case covers:\n *  - conditional line 30 branch to line 31\n */\n@org.powermock.core.classloader.annotations.PrepareForTest(org.apache.commons.codec.digest.DigestUtils.class)\n@org.junit.Test\npublic void isNeedleInHaystackInputNullOutputTrue() throws Exception {\n\n  // Setup mocks\n  org.powermock.api.mockito.PowerMockito.mockStatic(org.apache.commons.codec.digest.DigestUtils.class);\n\n  // Arrange\n  final com.diffblue.javademo.Search objectUnderTest = new com.diffblue.javademo.Search();\n  final String input = null;\n  final java.lang.reflect.Method sha1HexMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.apache.commons.codec.digest.DigestUtils.class, \"sha1Hex\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(\"3b6e258214f894ab41c9deaaeb38d1fd9aeca9c7\").when(org.apache.commons.codec.digest.DigestUtils.class, sha1HexMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n\n  // Act\n  final boolean retval = objectUnderTest.isNeedleInHaystack(input);\n\n  // Assert result\n  Assert.assertEquals(true, retval);\n\n}",
-            "tags": []
-        }
-    ],
-    "cursor": 1556639125864,
-    "status": {
-        "status": "COMPLETED"
-    }
+  "results": [
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,12,13"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368496739,
+          "testId": "hasItemOutputFalse0000563cdfa670afaa0",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void hasItemOutputFalse0000563cdfa670afaa0() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act and Assert result\n  Assert.assertFalse(order.hasItem());\n\n}",
+          "testName": "hasItemOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368498251,
+          "testId": "constructorOutputNotNull0009d2a39eb31cf9114",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.<init>:()V",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorOutputNotNull0009d2a39eb31cf9114() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.subpackage.Order actual = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n  Assert.assertNull(actual.item);\n\n}",
+          "testName": "constructorOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5",
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,12,13,23-25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368499790,
+          "testId": "setItemInputNotNullOutputFalse000ca6eb9a233bab698",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setItemInputNotNullOutputFalse000ca6eb9a233bab698() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Act and Assert result\n  Assert.assertFalse(order.setItem(item));\n\n  // Assert side effects\n  Assert.assertNotNull(order.item);\n  Assert.assertEquals(0, order.item.cost);\n\n}",
+          "testName": "setItemInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,32"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368501310,
+          "testId": "getItemOutputNull0001b4c0badd4f57ddf",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.getItem:()Lcom/diffblue/javademo/nestedobjects/subpackage/Item;",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void getItemOutputNull0001b4c0badd4f57ddf() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act and Assert result\n  Assert.assertNull(order.getItem());\n\n}",
+          "testName": "getItemOutputNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368503119,
+          "testId": "constructorOutputNotNull000e36907d0d5491a5a",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Item.<init>:()V",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Item.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorOutputNotNull() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.subpackage.Item actual = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n  Assert.assertEquals(0, actual.cost);\n\n}",
+          "testName": "constructorOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7"
+          ],
+          "imports": [
+              "com.diffblue.javademo.Search",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368504518,
+          "testId": "constructorOutputNotNull000e8b0c0991a4e58fa",
+          "testedFunction": "java::com.diffblue.javademo.Search.<init>:()V",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorOutputNotNull() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.Search actual = new com.diffblue.javademo.Search();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,12,14,20"
+          ],
+          "imports": [
+              "com.diffblue.javademo.Search",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368507070,
+          "testId": "containsInput0ZeroOutputFalse000a67f1e33f770d3a1",
+          "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void containsInput0ZeroOutputFalse000a67f1e33f770d3a1() {\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final int[] array = { };\n\n  // Act and Assert result\n  Assert.assertFalse(search.contains(array, 0));\n\n}",
+          "testName": "containsInput0ZeroOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "org/cprover/CProverString.java:156,159",
+              "java/lang/String.java:851,1585,1586",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,29,30,33"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.Search",
+              "org.apache.commons.codec.digest.DigestUtils",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull",
+              "org.powermock.api.mockito.PowerMockito.mockStatic"
+          ],
+          "tags": [
+              "no_reflection",
+              "mocking",
+              "assertions",
+              "two_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368509262,
+          "testId": "isNeedleInHaystackInputNotNullOutputFalse0000bdedb26a4c7c784",
+          "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest(org.apache.commons.codec.digest.DigestUtils.class)\n@org.junit.Test\npublic void isNeedleInHaystackInputNotNullOutputFalse0000bdedb26a4c7c784() throws Exception {\n\n  // Setup mocks\n  org.powermock.api.mockito.PowerMockito.mockStatic(org.apache.commons.codec.digest.DigestUtils.class);\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final String input = \"foo\";\n  final java.lang.reflect.Method sha1HexMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.apache.commons.codec.digest.DigestUtils.class, \"sha1Hex\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(\"foo\").when(org.apache.commons.codec.digest.DigestUtils.class, sha1HexMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n\n  // Act\n  final boolean actual = search.isNeedleInHaystack(input);\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "isNeedleInHaystackInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368511535,
+          "testId": "constructorInputNotNullOutputNotNull000093d8058ff13b661",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorInputNotNullOutputNotNull000093d8058ff13b661() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.User actual = new com.diffblue.javademo.nestedobjects.User(order);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorInputNotNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5",
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,12,13",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10,17,18"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368513717,
+          "testId": "checkItemCostInputNotNullOutputFalse000e5fcab89dbaca23b",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputFalse000e5fcab89dbaca23b() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.User user = new com.diffblue.javademo.nestedobjects.User(order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n\n  // Act and Assert result\n  Assert.assertFalse(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10,26,27"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368515257,
+          "testId": "setOrderInputNotNullOutputNotNull00044fba0f6d6c2e09c",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setOrderInputNotNullOutputNotNull00044fba0f6d6c2e09c() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.User user = new com.diffblue.javademo.nestedobjects.User(order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Order newOrder = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.User actual = user.setOrder(newOrder);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "setOrderInputNotNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10,31"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_3"
+          ],
+          "createdTime": 1568368516726,
+          "testId": "getOrderOutputNotNull000bfaa0e54934db426",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.getOrder:()Lcom/diffblue/javademo/nestedobjects/subpackage/Order;",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void getOrderOutputNotNull000bfaa0e54934db426() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.User user = new com.diffblue.javademo.nestedobjects.User(order);\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.subpackage.Order actual = user.getOrder();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n  Assert.assertNull(actual.getItem());\n\n}",
+          "testName": "getOrderOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368518221,
+          "testId": "constructorOutputNotNull0004903fc78a979ff55",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.<init>:()V",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorOutputNotNull() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.TicTacToe actual = new com.diffblue.javademo.TicTacToe();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-27,29,31,32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368519710,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException000eb30b08ae19518c7",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { -2_147_483_648, 0, 0, 0, 0, 0, 0, 0, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,21",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368519936,
+          "testId": "checkTicTacToePositionInput8OutputIllegalArgumentException0014823df215f518b17",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput8OutputIllegalArgumentException() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { -2_147_483_648, 0, 0, 0, 0, 0, 0, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput8OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40-42"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoDatabase",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "no_assertions",
+              "one_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368521361,
+          "testId": "getInstanceOutputNotNull0004f2771e573038136",
+          "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getInstance:()Lcom/diffblue/javademo/serveraccess/DatabaseDao;",
+          "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void getInstanceOutputNotNull0004f2771e573038136() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = (com.mongodb.client.MongoDatabase) Reflector.getInstance(\"com.mongodb.client.MongoDatabase\");\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n\n  // Act\n  final com.diffblue.javademo.serveraccess.DatabaseDao actual = com.diffblue.javademo.serveraccess.DatabaseDao.getInstance();\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}\n",
+          "testName": "getInstanceOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8"
+          ],
+          "imports": [
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368527167,
+          "testId": "constructorOutputNotNull000eacb9c9cb0253214",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.<init>:()V",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorOutputNotNull000eacb9c9cb0253214() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.UserAccess actual = new com.diffblue.javademo.UserAccess();\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8,13"
+          ],
+          "imports": [
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_0"
+          ],
+          "createdTime": 1568368528746,
+          "testId": "getCurrentUserOutputNull00063ca10ded2d9f083",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.getCurrentUser:()Ljava/lang/String;",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void getCurrentUserOutputNull() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n\n  // Act and Assert result\n  Assert.assertNull(userAccess.getCurrentUser());\n\n}",
+          "testName": "getCurrentUserOutputNull"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33,38,39"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368531445,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0005f696bfc751c2092",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse0005f696bfc751c2092() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"foo\";\n  final String password = \"foo\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33-35"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368531790,
+          "testId": "loginUserInputNotNullNotNullOutputTrue0011fd6a71b0dfbd0fb",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue0011fd6a71b0dfbd0fb() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"foo\";\n  final String password = \"foo\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,12,14,15,20"
+          ],
+          "imports": [
+              "com.diffblue.javademo.Search",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368541417,
+          "testId": "containsInput1ZeroOutputFalse00127f3f831962d171b",
+          "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void containsInput1ZeroOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final int[] array = { 1 };\n\n  // Act and Assert result\n  Assert.assertFalse(search.contains(array, 0));\n\n}",
+          "testName": "containsInput1ZeroOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,12,14-16,20"
+          ],
+          "imports": [
+              "com.diffblue.javademo.Search",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368541710,
+          "testId": "containsInput3ZeroOutputTrue002d87e98f2d994450c",
+          "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void containsInput3ZeroOutputTrue() {\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final int[] array = { 1, 0, 1 };\n\n  // Act and Assert result\n  Assert.assertTrue(search.contains(array, 0));\n\n}",
+          "testName": "containsInput3ZeroOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-27,29,31,32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368552570,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException000e39ab72b63162e00",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException2() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 4, 0, 1, 2, 0, 0, 0, 0, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,21",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368552810,
+          "testId": "checkTicTacToePositionInput8OutputIllegalArgumentException001ea7f1bf7492be069",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput8OutputIllegalArgumentException2() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 4, 0, 1, 2, 0, 0, 0, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput8OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-29,31,32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368553164,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException002383e4bbfc89c506c",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException3() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 3, 0, 2, 1, 0, 0, 0, 1 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368553423,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException003c9ecfc0bfd7c8d87",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException4() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 2, 1, -2_147_483_648, 2, 2, 2, 0, 0, 1 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-29,31,32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_1"
+          ],
+          "createdTime": 1568368553686,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException0042bab8990f444d9f1",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException5() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 1, -2_147_483_648, 2, 2, 2, 0, 0, 1 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "org/cprover/CProverString.java:156,159",
+              "java/lang/String.java:851,1585,1586",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,29,30,33"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.Search",
+              "org.apache.commons.codec.digest.DigestUtils",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull",
+              "org.powermock.api.mockito.PowerMockito.mockStatic"
+          ],
+          "tags": [
+              "no_reflection",
+              "mocking",
+              "assertions",
+              "two_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368568028,
+          "testId": "isNeedleInHaystackInputNotNullOutputFalse0007ed20c42e23e0f28",
+          "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest(org.apache.commons.codec.digest.DigestUtils.class)\n@org.junit.Test\npublic void isNeedleInHaystackInputNotNullOutputFalse2() throws Exception {\n\n  // Setup mocks\n  org.powermock.api.mockito.PowerMockito.mockStatic(org.apache.commons.codec.digest.DigestUtils.class);\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final String input = \"?\";\n  final java.lang.reflect.Method sha1HexMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.apache.commons.codec.digest.DigestUtils.class, \"sha1Hex\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(\"\").when(org.apache.commons.codec.digest.DigestUtils.class, sha1HexMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n\n  // Act\n  final boolean actual = search.isNeedleInHaystack(input);\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "isNeedleInHaystackInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "org/cprover/CProverString.java:156,159",
+              "java/lang/String.java:851,1585,1586,2102",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/Search.java:7,29-31"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.Search",
+              "org.apache.commons.codec.digest.DigestUtils",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull",
+              "org.powermock.api.mockito.PowerMockito.mockStatic"
+          ],
+          "tags": [
+              "no_reflection",
+              "mocking",
+              "assertions",
+              "two_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368568253,
+          "testId": "isNeedleInHaystackInputNotNullOutputTrue001bffc3865042c4b2c",
+          "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/Search.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest(org.apache.commons.codec.digest.DigestUtils.class)\n@org.junit.Test\npublic void isNeedleInHaystackInputNotNullOutputTrue() throws Exception {\n\n  // Setup mocks\n  org.powermock.api.mockito.PowerMockito.mockStatic(org.apache.commons.codec.digest.DigestUtils.class);\n\n  // Arrange\n  final com.diffblue.javademo.Search search = new com.diffblue.javademo.Search();\n  final String input = \"?\";\n  final java.lang.reflect.Method sha1HexMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.apache.commons.codec.digest.DigestUtils.class, \"sha1Hex\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(\"3b6e258214f894ab41c9deaaeb38d1fd9aeca9c7\").when(org.apache.commons.codec.digest.DigestUtils.class, sha1HexMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n\n  // Act\n  final boolean actual = search.isNeedleInHaystack(input);\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "isNeedleInHaystackInputNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-27,29,31,37,44-46,48,53,54,56,63,64,66,72,73,75,81"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368577054,
+          "testId": "checkTicTacToePositionInput9OutputZero00073de6bcf7d85ae78",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputZero() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(0, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-29,31,37,44-46,48,53,54,56,63,64,66,72,73,75,81"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368577353,
+          "testId": "checkTicTacToePositionInput9OutputZero00188635581a9f1edd7",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputZero2() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 0, 0, 0, 0, 0, 0, 1, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(0, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72,81"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368577682,
+          "testId": "checkTicTacToePositionInput9OutputZero002ae99d859caebcb66",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputZero3() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 2, 2, 1, 2, 1, 0, 1, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(0, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-32",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368577951,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException00370ad3241e21f89c5",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException6() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 2, 2, 1, 2, 1, -2_147_483_648, 1, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,38",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368578200,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException004d45a4aff4a0d5e6c",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException7() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 2, 2, 2, 2, 1, 0, 1, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44-47"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368578456,
+          "testId": "checkTicTacToePositionInput9OutputPositive005d51f2d93d059f0b1",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 2, 0, 1, 2, 2, 1, 1, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(1, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,21",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368578704,
+          "testId": "checkTicTacToePositionInput11OutputIllegalArgumentException006abd82042b60db5ff",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput11OutputIllegalArgumentException() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 2, 0, 1, 2, 2, 1, 1, 0, 0, 0 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput11OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,54,56,63,72,81"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368578922,
+          "testId": "checkTicTacToePositionInput9OutputZero007a0e2f84ad3cfc217",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputZero4() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 0, 0, 1, 2, 2, 1, 1, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(0, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,63-65"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368579229,
+          "testId": "checkTicTacToePositionInput9OutputPositive00876c545e1b9f8ce4a",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive2() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 1, 2, 1, 1, 2, 2, 2, 1 };\n\n  // Act and Assert result\n  Assert.assertEquals(1, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Throwable.java:201,280,282",
+              "java/lang/Exception.java:66",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,38",
+              "java/lang/Object.java:38",
+              "java/lang/IllegalArgumentException.java:35",
+              "java/lang/RuntimeException.java:36"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368579502,
+          "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException0090f28d55bfd920e4d",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputIllegalArgumentException8() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 1, 2, 1, 1, 2, 1, 2, 1 };\n\n  // Act\n  thrown.expect(IllegalArgumentException.class);\n  ticTacToe.checkTicTacToePosition(board);\n\n  // The method is not expected to return due to exception thrown\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputIllegalArgumentException"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,63,72,73,75,76"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "five_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368579736,
+          "testId": "checkTicTacToePositionInput9OutputPositive01023207d5eb562e4be",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive3() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 1, 2, 1, 2, 1, 2, 2, 1 };\n\n  // Act and Assert result\n  Assert.assertEquals(2, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72-74"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368580027,
+          "testId": "checkTicTacToePositionInput9OutputPositive01135c4b6f291069999",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive4() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 0, 1, 2, 1, 1, 1, 2, 2 };\n\n  // Act and Assert result\n  Assert.assertEquals(1, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72,81"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368581310,
+          "testId": "checkTicTacToePositionInput9OutputZero01208ed49df668ad090",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputZero5() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 2, 2, 2, 1, 1, 2, 0, 0 };\n\n  // Act and Assert result\n  Assert.assertEquals(0, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,54,56,57"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "five_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368581575,
+          "testId": "checkTicTacToePositionInput9OutputPositive01364cc5454f46fe076",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive5() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 1, 1, 2, 2, 1, 1, 2, 2, 2 };\n\n  // Act and Assert result\n  Assert.assertEquals(2, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,64,66,67"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "five_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368581894,
+          "testId": "checkTicTacToePositionInput9OutputPositive014056debb278798b03",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive6() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 2, 2, 1, 0, 2, 0, 1, 1, 2 };\n\n  // Act and Assert result\n  Assert.assertEquals(2, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44-46,48,49,53"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "five_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368583252,
+          "testId": "checkTicTacToePositionInput9OutputPositive0151d72e71d309856c8",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive7() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 0, 0, 2, 2, 1, 2, 1, 1, 2 };\n\n  // Act and Assert result\n  Assert.assertEquals(2, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53-56"
+          ],
+          "imports": [
+              "com.diffblue.javademo.TicTacToe",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "four_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368583517,
+          "testId": "checkTicTacToePositionInput9OutputPositive0167bff780c8dc2211e",
+          "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
+          "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkTicTacToePositionInput9OutputPositive8() throws IllegalArgumentException {\n\n  // Arrange\n  final com.diffblue.javademo.TicTacToe ticTacToe = new com.diffblue.javademo.TicTacToe();\n  final int[] board = { 2, 2, 0, 0, 0, 0, 1, 1, 1 };\n\n  // Act and Assert result\n  Assert.assertEquals(1, ticTacToe.checkTicTacToePosition(board));\n\n}",
+          "testName": "checkTicTacToePositionInput9OutputPositive"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8,24,28-30,33,38,39"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368589694,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0008e3f06deee74f674",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse2() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"?\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8,24,25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or"
+          ],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368589935,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0014752523ef7c8f49f",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse3() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"?\", \"\"));\n\n}",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8,24,28-30,33-35"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368590191,
+          "testId": "loginUserInputNotNullNotNullOutputTrue0025cfa3dc9937d1552",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue2() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"??\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final org.bson.Document document1 = (org.bson.Document) Reflector.getInstance(\"org.bson.Document\");\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(document1).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/UserAccess.java:8,24,25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or"
+          ],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_2"
+          ],
+          "createdTime": 1568368590424,
+          "testId": "loginUserInputNotNullNotNullOutputFalse003ecc1755419575f7f",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse4() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"\", \"??\"));\n\n}",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368610946,
+          "testId": "hasItemOutputFalse000e94f82a1bd8e612a",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void hasItemOutputFalse000e94f82a1bd8e612a() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n\n  // Act and Assert result\n  Assert.assertFalse(order.hasItem());\n\n}",
+          "testName": "hasItemOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368611159,
+          "testId": "hasItemOutputTrue0015b8d1173a38d724d",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void hasItemOutputTrue0015b8d1173a38d724d() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n  order.item = item;\n\n  // Act and Assert result\n  Assert.assertTrue(order.hasItem());\n\n}",
+          "testName": "hasItemOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13,23-25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368614268,
+          "testId": "setItemInputNotNullOutputFalse0003737a6fc7491dacc",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setItemInputNotNullOutputFalse2() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertFalse(order.setItem(item));\n\n  // Assert side effects\n  Assert.assertNotNull(order.item);\n  Assert.assertEquals(0, order.item.cost);\n\n}",
+          "testName": "setItemInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15,23-25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368614457,
+          "testId": "setItemInputNotNullOutputTrue0017bf497705de390d9",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setItemInputNotNullOutputTrue() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = 0;\n  order.item = item1;\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertTrue(order.setItem(item));\n\n}",
+          "testName": "setItemInputNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368616032,
+          "testId": "constructorInputNotNullOutputNotNull0002cf88447037d3d9f",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorInputNotNullOutputNotNull2() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.User actual = new com.diffblue.javademo.nestedobjects.User(order);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorInputNotNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13",
+              "com/diffblue/javademo/nestedobjects/User.java:17,18"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368617527,
+          "testId": "checkItemCostInputNotNullOutputFalse000d143c36ac93d8051",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputFalse2() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertFalse(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
+              "com/diffblue/javademo/nestedobjects/User.java:17,20"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368617755,
+          "testId": "checkItemCostInputNotNullOutputFalse00187abd2b169b79b70",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputFalse00187abd2b169b79b70() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = -2_147_483_648;\n  order.item = item1;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertFalse(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
+              "com/diffblue/javademo/nestedobjects/User.java:17,20"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368617964,
+          "testId": "checkItemCostInputNotNullOutputTrue002265c9fbbce2ca4a0",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputTrue002265c9fbbce2ca4a0() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = -2_147_483_648;\n  order.item = item1;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = -2_147_483_648;\n\n  // Act and Assert result\n  Assert.assertTrue(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/User.java:26,27"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "no_assertions",
+              "one_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368619459,
+          "testId": "setOrderInputNotNullOutputNotNull0007f5e930c5d8c712b",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setOrderInputNotNullOutputNotNull2() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  Reflector.setField(user, \"order\", null);\n  final com.diffblue.javademo.nestedobjects.subpackage.Order newOrder = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  newOrder.item = null;\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.User actual = user.setOrder(newOrder);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "setOrderInputNotNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:51,52"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_4"
+          ],
+          "createdTime": 1568368622433,
+          "testId": "getCountFromDbInputNotNullNotNullOutputZero000f16edfff924ac843",
+          "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getCountFromDb:(Ljava/lang/String;Lorg/bson/Document;)I",
+          "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoCollection.class, com.mongodb.client.MongoDatabase.class})\n@org.junit.Test\npublic void getCountFromDbInputNotNullNotNullOutputZero() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.serveraccess.DatabaseDao databaseDao = (com.diffblue.javademo.serveraccess.DatabaseDao) Reflector.getInstance(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  Reflector.setField(databaseDao, \"port\", 0);\n  Reflector.setField(databaseDao, \"hostname\", null);\n  Reflector.setField(databaseDao, \"dbName\", null);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection<org.bson.Document> mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  Reflector.setField(databaseDao, \"mongoDatabase\", mongoDatabase);\n  final org.bson.Document searchFor = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n\n  // Act and Assert result\n  Assert.assertEquals(0, databaseDao.getCountFromDb(\"foo\", searchFor));\n\n}",
+          "testName": "getCountFromDbInputNotNullNotNullOutputZero"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13,23-25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368631684,
+          "testId": "setItemInputNullOutputFalse0000710562f8687bb05",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setItemInputNullOutputFalse0000710562f8687bb05() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n\n  // Act and Assert result\n  Assert.assertFalse(order.setItem(null));\n\n}",
+          "testName": "setItemInputNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15,23-25"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "assertions",
+              "three_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368631878,
+          "testId": "setItemInputNullOutputTrue0014918ca02596e9a93",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setItemInputNullOutputTrue0014918ca02596e9a93() {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = 0;\n  order.item = item1;\n\n  // Act and Assert result\n  Assert.assertTrue(order.setItem(null));\n\n  // Assert side effects\n  Assert.assertNull(order.item);\n\n}",
+          "testName": "setItemInputNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/nestedobjects/User.java:9,10"
+          ],
+          "imports": [
+              "com.diffblue.javademo.nestedobjects.User",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "no_reflection",
+              "no_mocking",
+              "no_assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368633490,
+          "testId": "constructorInputNullOutputNotNull000f14c1791e5146dc0",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void constructorInputNullOutputNotNull000f14c1791e5146dc0() {\n\n  // Act, creating object to test constructor\n  final com.diffblue.javademo.nestedobjects.User actual = new com.diffblue.javademo.nestedobjects.User(null);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "constructorInputNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13",
+              "com/diffblue/javademo/nestedobjects/User.java:17,18"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368635291,
+          "testId": "checkItemCostInputNullOutputFalse0003f87bfa5669e7fc6",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNullOutputFalse0003f87bfa5669e7fc6() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  order.item = null;\n  Reflector.setField(user, \"order\", order);\n\n  // Act and Assert result\n  Assert.assertFalse(user.checkItemCost(null));\n\n}",
+          "testName": "checkItemCostInputNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
+              "com/diffblue/javademo/nestedobjects/User.java:17,20"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_5"
+          ],
+          "createdTime": 1568368635734,
+          "testId": "checkItemCostInputNotNullOutputTrue0022e32832821f2fc17",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputTrue2() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = 0;\n  order.item = item1;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertTrue(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/User.java:26,27"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "no_assertions",
+              "one_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368638548,
+          "testId": "setOrderInputNullOutputNotNull000a186269e616c78d9",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void setOrderInputNullOutputNotNull000a186269e616c78d9() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  Reflector.setField(user, \"order\", null);\n\n  // Act\n  final com.diffblue.javademo.nestedobjects.User actual = user.setOrder(null);\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}",
+          "testName": "setOrderInputNullOutputNotNull"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40-42"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "no_assertions",
+              "one_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368640029,
+          "testId": "getInstanceOutputNotNull000df4ffce0524f2739",
+          "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getInstance:()Lcom/diffblue/javademo/serveraccess/DatabaseDao;",
+          "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void getInstanceOutputNotNull000df4ffce0524f2739() throws Exception {\n\n  // Arrange\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n\n  // Act\n  final com.diffblue.javademo.serveraccess.DatabaseDao actual = com.diffblue.javademo.serveraccess.DatabaseDao.getInstance();\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertNotNull(actual);\n\n}\n",
+          "testName": "getInstanceOutputNotNull"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:51,52"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368641928,
+          "testId": "getCountFromDbInputNullNullOutputZero000240e8d97d437904d",
+          "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getCountFromDb:(Ljava/lang/String;Lorg/bson/Document;)I",
+          "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoCollection.class, com.mongodb.client.MongoDatabase.class})\n@org.junit.Test\npublic void getCountFromDbInputNullNullOutputZero000240e8d97d437904d() throws Exception, java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.serveraccess.DatabaseDao databaseDao = (com.diffblue.javademo.serveraccess.DatabaseDao) Reflector.getInstance(\"com.diffblue.javademo.serveraccess.DatabaseDao\");\n  Reflector.setField(databaseDao, \"port\", 0);\n  Reflector.setField(databaseDao, \"hostname\", null);\n  Reflector.setField(databaseDao, \"dbName\", null);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection<org.bson.Document> mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  Reflector.setField(databaseDao, \"mongoDatabase\", mongoDatabase);\n\n  // Act and Assert result\n  Assert.assertEquals(0, databaseDao.getCountFromDb(null, null));\n\n}",
+          "testName": "getCountFromDbInputNullNullOutputZero"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33,38,39"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_5"
+          ],
+          "createdTime": 1568368645431,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0002fbdf29fd1659747",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse5() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"foo\";\n  final String password = \"foo\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33-35"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_5"
+          ],
+          "createdTime": 1568368646136,
+          "testId": "loginUserInputNotNullNotNullOutputTrue001dc428db7a1f40c8a",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue3() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"foo\";\n  final String password = \"foo\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33,38,39"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368667266,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0009bd811bb64afa0a6",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse0009bd811bb64afa0a6() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"?\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33-35"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368667526,
+          "testId": "loginUserInputNotNullNotNullOutputTrue0011283edb7e0d812f2",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue0011283edb7e0d812f2() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"?\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,25"
+          ],
+          "imports": [
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or"
+          ],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368667792,
+          "testId": "loginUserInputNotNullNotNullOutputFalse002c69a479635c59106",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse002c69a479635c59106() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", \"\");\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"\", \"?\"));\n\n}",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,25"
+          ],
+          "imports": [
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or"
+          ],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_9"
+          ],
+          "createdTime": 1568368668164,
+          "testId": "loginUserInputNotNullNotNullOutputFalse003dfeaa8b9e2c344a4",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse003dfeaa8b9e2c344a4() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", \"\");\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"????????????????\", \"\"));\n\n}",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
+              "com/diffblue/javademo/nestedobjects/User.java:17,20"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368734326,
+          "testId": "checkItemCostInputNotNullOutputTrue0012e32832821f2fc17",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputTrue3() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = 0;\n  order.item = item1;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertTrue(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputTrue"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
+              "com/diffblue/javademo/nestedobjects/User.java:17,20"
+          ],
+          "imports": [
+              "java.lang.reflect.InvocationTargetException",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.nestedobjects.User",
+              "com.diffblue.javademo.nestedobjects.subpackage.Item",
+              "com.diffblue.javademo.nestedobjects.subpackage.Order",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368734536,
+          "testId": "checkItemCostInputNotNullOutputFalse0020260ba3b10290e03",
+          "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
+          "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void checkItemCostInputNotNullOutputFalse4() throws java.lang.reflect.InvocationTargetException {\n\n  // Arrange\n  final com.diffblue.javademo.nestedobjects.User user = (com.diffblue.javademo.nestedobjects.User) Reflector.getInstance(\"com.diffblue.javademo.nestedobjects.User\");\n  final com.diffblue.javademo.nestedobjects.subpackage.Order order = new com.diffblue.javademo.nestedobjects.subpackage.Order();\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item1 = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item1.cost = 1;\n  order.item = item1;\n  Reflector.setField(user, \"order\", order);\n  final com.diffblue.javademo.nestedobjects.subpackage.Item item = new com.diffblue.javademo.nestedobjects.subpackage.Item();\n  item.cost = 0;\n\n  // Act and Assert result\n  Assert.assertFalse(user.checkItemCost(item));\n\n}",
+          "testName": "checkItemCostInputNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,25"
+          ],
+          "imports": [
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368746206,
+          "testId": "loginUserInputNotNullNullOutputFalse000e80da2209fdcf9b3",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNullOutputFalse() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"\", null));\n\n}",
+          "testName": "loginUserInputNotNullNullOutputFalse"
+      },
+      {
+          "classAnnotations": [],
+          "coveredLines": [
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,25"
+          ],
+          "imports": [
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.javademo.UserAccess",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout"
+          ],
+          "staticImports": [],
+          "tags": [
+              "reflection",
+              "no_mocking",
+              "assertions",
+              "two_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368746526,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0010b9073cc63abfe0f",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse9() {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n\n  // Act and Assert result\n  Assert.assertFalse(userAccess.loginUser(\"?\", \"\"));\n\n}",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33,38,39"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368749493,
+          "testId": "loginUserInputNotNullNotNullOutputFalse0029bd811bb64afa0a6",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputFalse10() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"?\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(0L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertFalse(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputFalse"
+      },
+      {
+          "classAnnotations": [
+              "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "coveredLines": [
+              "java/lang/Object.java:38",
+              "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
+              "java/lang/String.java:851",
+              "com/diffblue/javademo/UserAccess.java:24,28-30,33-35"
+          ],
+          "imports": [
+              "java.lang.reflect.Method",
+              "com.diffblue.deeptestutils.Reflector",
+              "com.diffblue.deeptestutils.mock.DTUMemberMatcher",
+              "com.diffblue.javademo.UserAccess",
+              "com.diffblue.javademo.serveraccess.DatabaseDao",
+              "com.mongodb.MongoClient",
+              "com.mongodb.client.MongoCollection",
+              "com.mongodb.client.MongoDatabase",
+              "org.bson.Document",
+              "org.bson.conversions.Bson",
+              "org.junit.Assert",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.rules.ExpectedException",
+              "org.junit.rules.Timeout",
+              "org.junit.runner.RunWith",
+              "org.powermock.api.mockito.PowerMockito",
+              "org.powermock.core.classloader.annotations.PrepareForTest",
+              "org.powermock.modules.junit4.PowerMockRunner"
+          ],
+          "staticImports": [
+              "org.mockito.AdditionalMatchers.or",
+              "org.mockito.Matchers.anyInt",
+              "org.mockito.Matchers.isA",
+              "org.mockito.Matchers.isNull"
+          ],
+          "tags": [
+              "reflection",
+              "mocking",
+              "assertions",
+              "one_star",
+              "phase_10"
+          ],
+          "createdTime": 1568368749846,
+          "testId": "loginUserInputNotNullNotNullOutputTrue0031283edb7e0d812f2",
+          "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
+          "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
+          "testBody": "// Test written by Diffblue Cover.\n@org.powermock.core.classloader.annotations.PrepareForTest({com.mongodb.client.MongoDatabase.class, com.diffblue.javademo.UserAccess.class, com.mongodb.client.MongoCollection.class, org.bson.Document.class, com.mongodb.MongoClient.class, com.diffblue.javademo.serveraccess.DatabaseDao.class})\n@org.junit.Test\npublic void loginUserInputNotNullNotNullOutputTrue5() throws Exception {\n\n  // Arrange\n  final com.diffblue.javademo.UserAccess userAccess = new com.diffblue.javademo.UserAccess();\n  Reflector.setField(userAccess, \"currentUser\", null);\n  final String username = \"?\";\n  final String password = \"?\";\n  final com.mongodb.MongoClient mongoClient = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.MongoClient.class);\n  final com.mongodb.client.MongoDatabase mongoDatabase = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoDatabase.class);\n  final com.mongodb.client.MongoCollection mongoCollection = org.powermock.api.mockito.PowerMockito.mock(com.mongodb.client.MongoCollection.class);\n  final java.lang.reflect.Method countMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoCollection.class, \"count\", org.bson.conversions.Bson.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(1L).when(mongoCollection, countMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(org.bson.conversions.Bson.class), org.mockito.Matchers.isNull(org.bson.conversions.Bson.class)));\n  final java.lang.reflect.Method getCollectionMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.client.MongoDatabase.class, \"getCollection\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoCollection).when(mongoDatabase, getCollectionMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  final java.lang.reflect.Method getDatabaseMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(com.mongodb.MongoClient.class, \"getDatabase\", String.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(mongoDatabase).when(mongoClient, getDatabaseMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(com.mongodb.MongoClient.class).withParameterTypes(String.class, int.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.Matchers.anyInt()).thenReturn(mongoClient);\n  final org.bson.Document document = org.powermock.api.mockito.PowerMockito.mock(org.bson.Document.class);\n  final java.lang.reflect.Method appendMethod = com.diffblue.deeptestutils.mock.DTUMemberMatcher.method(org.bson.Document.class, \"append\", String.class, Object.class);\n  org.powermock.api.mockito.PowerMockito.doReturn(null).when(document, appendMethod).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class)));\n  org.powermock.api.mockito.PowerMockito.whenNew(org.bson.Document.class).withParameterTypes(String.class, Object.class).withArguments(org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(String.class), org.mockito.Matchers.isNull(String.class)), org.mockito.AdditionalMatchers.or(org.mockito.Matchers.isA(Object.class), org.mockito.Matchers.isNull(Object.class))).thenReturn(document);\n\n  // Act\n  final boolean actual = userAccess.loginUser(username, password);\n\n  // Assert side effects\n  Assert.assertNotNull(Reflector.getInstanceField(com.diffblue.javademo.serveraccess.DatabaseDao.class, null, \"instance\"));\n\n  // Assert result\n  Assert.assertTrue(actual);\n\n}\n",
+          "testName": "loginUserInputNotNullNotNullOutputTrue"
+      }
+  ],
+  "cursor": 1568368856458,
+  "status": {
+      "status": "COMPLETED"
+  }
 }

--- a/tests/integration/fixtures/sample-java-demo-results.json
+++ b/tests/integration/fixtures/sample-java-demo-results.json
@@ -2,6 +2,9 @@
   "results": [
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,12,13"
@@ -20,9 +23,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368496739,
+          "createdTime": 1568883943523,
           "testId": "hasItemOutputFalse0000563cdfa670afaa0",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -31,6 +38,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5"
@@ -49,9 +59,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368498251,
+          "createdTime": 1568883945179,
           "testId": "constructorOutputNotNull0009d2a39eb31cf9114",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.<init>:()V",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -60,6 +74,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5",
@@ -80,9 +97,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368499790,
+          "createdTime": 1568883946862,
           "testId": "setItemInputNotNullOutputFalse000ca6eb9a233bab698",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -91,6 +112,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,32"
@@ -109,9 +133,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368501310,
+          "createdTime": 1568883948731,
           "testId": "getItemOutputNull0001b4c0badd4f57ddf",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.getItem:()Lcom/diffblue/javademo/nestedobjects/subpackage/Item;",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -120,6 +148,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5"
@@ -138,9 +169,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368503119,
+          "createdTime": 1568883950471,
           "testId": "constructorOutputNotNull000e36907d0d5491a5a",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Item.<init>:()V",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Item.java",
@@ -149,6 +184,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/Search.java:7"
@@ -167,9 +205,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368504518,
+          "createdTime": 1568883952394,
           "testId": "constructorOutputNotNull000e8b0c0991a4e58fa",
           "testedFunction": "java::com.diffblue.javademo.Search.<init>:()V",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -178,6 +220,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/Search.java:7,12,14,20"
@@ -196,9 +241,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368507070,
+          "createdTime": 1568883954764,
           "testId": "containsInput0ZeroOutputFalse000a67f1e33f770d3a1",
           "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -208,6 +257,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "org/cprover/CProverString.java:156,159",
@@ -241,9 +293,13 @@
               "mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368509262,
+          "createdTime": 1568883956900,
           "testId": "isNeedleInHaystackInputNotNullOutputFalse0000bdedb26a4c7c784",
           "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -252,6 +308,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
               "java/lang/Object.java:38",
@@ -272,9 +331,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368511535,
+          "createdTime": 1568883958561,
           "testId": "constructorInputNotNullOutputNotNull000093d8058ff13b661",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -283,6 +346,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Item.java:5",
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5,12,13",
@@ -305,9 +371,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368513717,
+          "createdTime": 1568883960827,
           "testId": "checkItemCostInputNotNullOutputFalse000e5fcab89dbaca23b",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -316,6 +386,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
               "java/lang/Object.java:38",
@@ -336,9 +409,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368515257,
+          "createdTime": 1568883963374,
           "testId": "setOrderInputNotNullOutputNotNull00044fba0f6d6c2e09c",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -347,6 +424,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:5",
               "java/lang/Object.java:38",
@@ -367,9 +447,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_3"
           ],
-          "createdTime": 1568368516726,
+          "createdTime": 1568883966195,
           "testId": "getOrderOutputNotNull000bfaa0e54934db426",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.getOrder:()Lcom/diffblue/javademo/nestedobjects/subpackage/Order;",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -378,6 +462,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5"
@@ -396,9 +483,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368518221,
+          "createdTime": 1568883967962,
           "testId": "constructorOutputNotNull0004903fc78a979ff55",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.<init>:()V",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -407,6 +498,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -428,9 +523,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368519710,
+          "createdTime": 1568883969562,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException000eb30b08ae19518c7",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -439,6 +538,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -460,9 +563,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368519936,
+          "createdTime": 1568883969904,
           "testId": "checkTicTacToePositionInput8OutputIllegalArgumentException0014823df215f518b17",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -472,6 +579,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -506,9 +616,13 @@
               "mocking",
               "no_assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368521361,
+          "createdTime": 1568883971596,
           "testId": "getInstanceOutputNotNull0004f2771e573038136",
           "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getInstance:()Lcom/diffblue/javademo/serveraccess/DatabaseDao;",
           "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
@@ -517,6 +631,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/UserAccess.java:8"
@@ -535,9 +652,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368527167,
+          "createdTime": 1568883977132,
           "testId": "constructorOutputNotNull000eacb9c9cb0253214",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.<init>:()V",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -546,6 +667,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/UserAccess.java:8,13"
@@ -564,9 +688,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "natural_inputs",
               "phase_0"
           ],
-          "createdTime": 1568368528746,
+          "createdTime": 1568883978653,
           "testId": "getCurrentUserOutputNull00063ca10ded2d9f083",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.getCurrentUser:()Ljava/lang/String;",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -576,6 +704,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -616,9 +747,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368531445,
+          "createdTime": 1568883980333,
           "testId": "loginUserInputNotNullNotNullOutputFalse0005f696bfc751c2092",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -628,6 +763,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -668,9 +806,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368531790,
+          "createdTime": 1568883980664,
           "testId": "loginUserInputNotNullNotNullOutputTrue0011fd6a71b0dfbd0fb",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -679,6 +821,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/Search.java:7,12,14,15,20"
@@ -697,9 +842,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368541417,
+          "createdTime": 1568883989041,
           "testId": "containsInput1ZeroOutputFalse00127f3f831962d171b",
           "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -708,6 +857,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/Search.java:7,12,14-16,20"
@@ -726,9 +878,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368541710,
+          "createdTime": 1568883989280,
           "testId": "containsInput3ZeroOutputTrue002d87e98f2d994450c",
           "testedFunction": "java::com.diffblue.javademo.Search.contains:([II)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -737,6 +893,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -758,9 +918,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368552570,
+          "createdTime": 1568883999131,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException000e39ab72b63162e00",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -769,6 +933,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -790,9 +958,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368552810,
+          "createdTime": 1568883999517,
           "testId": "checkTicTacToePositionInput8OutputIllegalArgumentException001ea7f1bf7492be069",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -801,6 +973,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -822,9 +998,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368553164,
+          "createdTime": 1568883999735,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException002383e4bbfc89c506c",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -833,6 +1013,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -854,9 +1038,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368553423,
+          "createdTime": 1568883999972,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException003c9ecfc0bfd7c8d87",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -865,6 +1053,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -886,9 +1078,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_1"
           ],
-          "createdTime": 1568368553686,
+          "createdTime": 1568884000223,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException0042bab8990f444d9f1",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -898,6 +1094,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "org/cprover/CProverString.java:156,159",
@@ -931,9 +1130,13 @@
               "mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368568028,
+          "createdTime": 1568884014583,
           "testId": "isNeedleInHaystackInputNotNullOutputFalse0007ed20c42e23e0f28",
           "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -943,6 +1146,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "org/cprover/CProverString.java:156,159",
@@ -976,9 +1182,13 @@
               "mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368568253,
+          "createdTime": 1568884014785,
           "testId": "isNeedleInHaystackInputNotNullOutputTrue001bffc3865042c4b2c",
           "testedFunction": "java::com.diffblue.javademo.Search.isNeedleInHaystack:(Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/Search.java",
@@ -987,6 +1197,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-27,29,31,37,44-46,48,53,54,56,63,64,66,72,73,75,81"
@@ -1005,9 +1218,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368577054,
+          "createdTime": 1568884022741,
           "testId": "checkTicTacToePositionInput9OutputZero00073de6bcf7d85ae78",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1016,6 +1233,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-29,31,37,44-46,48,53,54,56,63,64,66,72,73,75,81"
@@ -1034,9 +1254,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368577353,
+          "createdTime": 1568884023098,
           "testId": "checkTicTacToePositionInput9OutputZero00188635581a9f1edd7",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1045,6 +1269,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72,81"
@@ -1063,9 +1290,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368577682,
+          "createdTime": 1568884023509,
           "testId": "checkTicTacToePositionInput9OutputZero002ae99d859caebcb66",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1074,6 +1305,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -1095,9 +1330,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368577951,
+          "createdTime": 1568884024011,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException00370ad3241e21f89c5",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1106,6 +1345,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -1127,9 +1370,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368578200,
+          "createdTime": 1568884024308,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException004d45a4aff4a0d5e6c",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1138,6 +1385,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44-47"
@@ -1156,9 +1406,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368578456,
+          "createdTime": 1568884024552,
           "testId": "checkTicTacToePositionInput9OutputPositive005d51f2d93d059f0b1",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1167,6 +1421,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -1188,9 +1446,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368578704,
+          "createdTime": 1568884024807,
           "testId": "checkTicTacToePositionInput11OutputIllegalArgumentException006abd82042b60db5ff",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1199,6 +1461,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,54,56,63,72,81"
@@ -1217,9 +1482,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368578922,
+          "createdTime": 1568884025003,
           "testId": "checkTicTacToePositionInput9OutputZero007a0e2f84ad3cfc217",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1228,6 +1497,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,63-65"
@@ -1246,9 +1518,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368579229,
+          "createdTime": 1568884025289,
           "testId": "checkTicTacToePositionInput9OutputPositive00876c545e1b9f8ce4a",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1257,6 +1533,10 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);",
+              "@org.junit.Rule public final org.junit.rules.ExpectedException thrown = org.junit.rules.ExpectedException.none();"
+          ],
           "coveredLines": [
               "java/lang/Throwable.java:201,280,282",
               "java/lang/Exception.java:66",
@@ -1278,9 +1558,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368579502,
+          "createdTime": 1568884025584,
           "testId": "checkTicTacToePositionInput9OutputIllegalArgumentException0090f28d55bfd920e4d",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1289,6 +1573,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,63,72,73,75,76"
@@ -1307,9 +1594,13 @@
               "no_mocking",
               "assertions",
               "five_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "natural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368579736,
+          "createdTime": 1568884025880,
           "testId": "checkTicTacToePositionInput9OutputPositive01023207d5eb562e4be",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1318,6 +1609,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72-74"
@@ -1336,9 +1630,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368580027,
+          "createdTime": 1568884026226,
           "testId": "checkTicTacToePositionInput9OutputPositive01135c4b6f291069999",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1347,6 +1645,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,72,81"
@@ -1365,9 +1666,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368581310,
+          "createdTime": 1568884026549,
           "testId": "checkTicTacToePositionInput9OutputZero01208ed49df668ad090",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1376,6 +1681,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-30,37,44,45,53,54,56,57"
@@ -1394,9 +1702,13 @@
               "no_mocking",
               "assertions",
               "five_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "natural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368581575,
+          "createdTime": 1568884026905,
           "testId": "checkTicTacToePositionInput9OutputPositive01364cc5454f46fe076",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1405,6 +1717,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53,63,64,66,67"
@@ -1423,9 +1738,13 @@
               "no_mocking",
               "assertions",
               "five_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "natural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368581894,
+          "createdTime": 1568884027229,
           "testId": "checkTicTacToePositionInput9OutputPositive014056debb278798b03",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1434,6 +1753,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44-46,48,49,53"
@@ -1452,9 +1774,13 @@
               "no_mocking",
               "assertions",
               "five_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "natural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368583252,
+          "createdTime": 1568884027560,
           "testId": "checkTicTacToePositionInput9OutputPositive0151d72e71d309856c8",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1463,6 +1789,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/TicTacToe.java:5,20,25-31,37,44,45,53-56"
@@ -1481,9 +1810,13 @@
               "no_mocking",
               "assertions",
               "four_star",
+              "no_nulls",
+              "no_exceptions",
+              "high_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368583517,
+          "createdTime": 1568884027856,
           "testId": "checkTicTacToePositionInput9OutputPositive0167bff780c8dc2211e",
           "testedFunction": "java::com.diffblue.javademo.TicTacToe.checkTicTacToePosition:([I)I",
           "sourceFilePath": "com/diffblue/javademo/TicTacToe.java",
@@ -1493,6 +1826,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -1533,9 +1869,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368589694,
+          "createdTime": 1568884034030,
           "testId": "loginUserInputNotNullNotNullOutputFalse0008e3f06deee74f674",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -1544,6 +1884,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "java/lang/Object.java:38",
@@ -1565,9 +1908,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368589935,
+          "createdTime": 1568884034383,
           "testId": "loginUserInputNotNullNotNullOutputFalse0014752523ef7c8f49f",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -1577,6 +1924,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -1617,9 +1967,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368590191,
+          "createdTime": 1568884034609,
           "testId": "loginUserInputNotNullNotNullOutputTrue0025cfa3dc9937d1552",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -1628,6 +1982,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "java/lang/Object.java:38",
@@ -1649,9 +2006,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_2"
           ],
-          "createdTime": 1568368590424,
+          "createdTime": 1568884034865,
           "testId": "loginUserInputNotNullNotNullOutputFalse003ecc1755419575f7f",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -1660,6 +2021,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13"
           ],
@@ -1677,9 +2041,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368610946,
+          "createdTime": 1568884055412,
           "testId": "hasItemOutputFalse000e94f82a1bd8e612a",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -1688,6 +2056,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15"
           ],
@@ -1706,9 +2077,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368611159,
+          "createdTime": 1568884055604,
           "testId": "hasItemOutputTrue0015b8d1173a38d724d",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.hasItem:()Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -1717,6 +2092,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13,23-25"
           ],
@@ -1735,9 +2113,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368614268,
+          "createdTime": 1568884058576,
           "testId": "setItemInputNotNullOutputFalse0003737a6fc7491dacc",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -1746,6 +2128,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15,23-25"
           ],
@@ -1764,9 +2149,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368614457,
+          "createdTime": 1568884058778,
           "testId": "setItemInputNotNullOutputTrue0017bf497705de390d9",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -1775,6 +2164,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/User.java:9,10"
@@ -1794,9 +2186,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368616032,
+          "createdTime": 1568884060470,
           "testId": "constructorInputNotNullOutputNotNull0002cf88447037d3d9f",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -1805,6 +2201,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13",
               "com/diffblue/javademo/nestedobjects/User.java:17,18"
@@ -1827,9 +2226,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368617527,
+          "createdTime": 1568884062103,
           "testId": "checkItemCostInputNotNullOutputFalse000d143c36ac93d8051",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -1838,6 +2241,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
               "com/diffblue/javademo/nestedobjects/User.java:17,20"
@@ -1860,9 +2266,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368617755,
+          "createdTime": 1568884062303,
           "testId": "checkItemCostInputNotNullOutputFalse00187abd2b169b79b70",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -1871,6 +2281,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
               "com/diffblue/javademo/nestedobjects/User.java:17,20"
@@ -1893,9 +2306,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368617964,
+          "createdTime": 1568884062498,
           "testId": "checkItemCostInputNotNullOutputTrue002265c9fbbce2ca4a0",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -1904,6 +2321,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/User.java:26,27"
           ],
@@ -1924,9 +2344,13 @@
               "no_mocking",
               "no_assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368619459,
+          "createdTime": 1568884064004,
           "testId": "setOrderInputNotNullOutputNotNull0007f5e930c5d8c712b",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -1936,6 +2360,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:51,52"
@@ -1970,9 +2397,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_4"
           ],
-          "createdTime": 1568368622433,
+          "createdTime": 1568884067041,
           "testId": "getCountFromDbInputNotNullNotNullOutputZero000f16edfff924ac843",
           "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getCountFromDb:(Ljava/lang/String;Lorg/bson/Document;)I",
           "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
@@ -1981,6 +2412,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13,23-25"
           ],
@@ -1998,9 +2432,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368631684,
+          "createdTime": 1568884075478,
           "testId": "setItemInputNullOutputFalse0000710562f8687bb05",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -2009,6 +2447,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15,23-25"
           ],
@@ -2027,9 +2468,13 @@
               "no_mocking",
               "assertions",
               "three_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368631878,
+          "createdTime": 1568884075673,
           "testId": "setItemInputNullOutputTrue0014918ca02596e9a93",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.subpackage.Order.setItem:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/subpackage/Order.java",
@@ -2038,6 +2483,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/nestedobjects/User.java:9,10"
@@ -2056,9 +2504,13 @@
               "no_mocking",
               "no_assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368633490,
+          "createdTime": 1568884077191,
           "testId": "constructorInputNullOutputNotNull000f14c1791e5146dc0",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.<init>:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)V",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2067,6 +2519,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,13",
               "com/diffblue/javademo/nestedobjects/User.java:17,18"
@@ -2088,9 +2543,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368635291,
+          "createdTime": 1568884078677,
           "testId": "checkItemCostInputNullOutputFalse0003f87bfa5669e7fc6",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2099,6 +2558,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
               "com/diffblue/javademo/nestedobjects/User.java:17,20"
@@ -2121,9 +2583,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_5"
           ],
-          "createdTime": 1568368635734,
+          "createdTime": 1568884079070,
           "testId": "checkItemCostInputNotNullOutputTrue0022e32832821f2fc17",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2132,6 +2598,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/User.java:26,27"
           ],
@@ -2151,9 +2620,13 @@
               "no_mocking",
               "no_assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368638548,
+          "createdTime": 1568884080708,
           "testId": "setOrderInputNullOutputNotNull000a186269e616c78d9",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.setOrder:(Lcom/diffblue/javademo/nestedobjects/subpackage/Order;)Lcom/diffblue/javademo/nestedobjects/User;",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2163,6 +2636,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -2195,9 +2671,13 @@
               "mocking",
               "no_assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368640029,
+          "createdTime": 1568884082304,
           "testId": "getInstanceOutputNotNull000df4ffce0524f2739",
           "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getInstance:()Lcom/diffblue/javademo/serveraccess/DatabaseDao;",
           "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
@@ -2207,6 +2687,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:51,52"
@@ -2241,9 +2724,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368641928,
+          "createdTime": 1568884083896,
           "testId": "getCountFromDbInputNullNullOutputZero000240e8d97d437904d",
           "testedFunction": "java::com.diffblue.javademo.serveraccess.DatabaseDao.getCountFromDb:(Ljava/lang/String;Lorg/bson/Document;)I",
           "sourceFilePath": "com/diffblue/javademo/serveraccess/DatabaseDao.java",
@@ -2254,6 +2741,9 @@
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
           ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -2292,9 +2782,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_5"
           ],
-          "createdTime": 1568368645431,
+          "createdTime": 1568884087227,
           "testId": "loginUserInputNotNullNotNullOutputFalse0002fbdf29fd1659747",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2305,6 +2799,9 @@
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
           ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -2343,9 +2840,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_5"
           ],
-          "createdTime": 1568368646136,
+          "createdTime": 1568884087485,
           "testId": "loginUserInputNotNullNotNullOutputTrue001dc428db7a1f40c8a",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2356,6 +2857,9 @@
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
           ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -2394,9 +2898,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368667266,
+          "createdTime": 1568884108604,
           "testId": "loginUserInputNotNullNotNullOutputFalse0009bd811bb64afa0a6",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2407,6 +2915,9 @@
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
           ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/Object.java:38",
               "com/diffblue/javademo/serveraccess/DatabaseDao.java:15-17,19,29-31,33,40,41,51,52",
@@ -2445,9 +2956,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368667526,
+          "createdTime": 1568884108872,
           "testId": "loginUserInputNotNullNotNullOutputTrue0011283edb7e0d812f2",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2456,6 +2971,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "com/diffblue/javademo/UserAccess.java:24,25"
@@ -2477,9 +2995,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368667792,
+          "createdTime": 1568884109316,
           "testId": "loginUserInputNotNullNotNullOutputFalse002c69a479635c59106",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2488,6 +3010,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "com/diffblue/javademo/UserAccess.java:24,25"
@@ -2509,9 +3034,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_9"
           ],
-          "createdTime": 1568368668164,
+          "createdTime": 1568884109600,
           "testId": "loginUserInputNotNullNotNullOutputFalse003dfeaa8b9e2c344a4",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2520,6 +3049,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
               "com/diffblue/javademo/nestedobjects/User.java:17,20"
@@ -2542,9 +3074,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368734326,
+          "createdTime": 1568884186086,
           "testId": "checkItemCostInputNotNullOutputTrue0012e32832821f2fc17",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2553,6 +3089,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "com/diffblue/javademo/nestedobjects/subpackage/Order.java:12,15",
               "com/diffblue/javademo/nestedobjects/User.java:17,20"
@@ -2575,9 +3114,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "no_nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368734536,
+          "createdTime": 1568884186286,
           "testId": "checkItemCostInputNotNullOutputFalse0020260ba3b10290e03",
           "testedFunction": "java::com.diffblue.javademo.nestedobjects.User.checkItemCost:(Lcom/diffblue/javademo/nestedobjects/subpackage/Item;)Z",
           "sourceFilePath": "com/diffblue/javademo/nestedobjects/User.java",
@@ -2586,6 +3129,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "com/diffblue/javademo/UserAccess.java:24,25"
@@ -2605,9 +3151,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368746206,
+          "createdTime": 1568884196689,
           "testId": "loginUserInputNotNullNullOutputFalse000e80da2209fdcf9b3",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2616,6 +3166,9 @@
       },
       {
           "classAnnotations": [],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
+          ],
           "coveredLines": [
               "java/lang/String.java:851",
               "com/diffblue/javademo/UserAccess.java:24,25"
@@ -2635,9 +3188,13 @@
               "no_mocking",
               "assertions",
               "two_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368746526,
+          "createdTime": 1568884197000,
           "testId": "loginUserInputNotNullNotNullOutputFalse0010b9073cc63abfe0f",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2647,6 +3204,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -2686,9 +3246,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368749493,
+          "createdTime": 1568884198778,
           "testId": "loginUserInputNotNullNotNullOutputFalse0029bd811bb64afa0a6",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2698,6 +3262,9 @@
       {
           "classAnnotations": [
               "@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)"
+          ],
+          "classRules": [
+              "@org.junit.Rule public final org.junit.rules.Timeout globalTimeout = new org.junit.rules.Timeout(10000);"
           ],
           "coveredLines": [
               "java/lang/Object.java:38",
@@ -2737,9 +3304,13 @@
               "mocking",
               "assertions",
               "one_star",
+              "nulls",
+              "no_exceptions",
+              "low_complexity",
+              "unnatural_inputs",
               "phase_10"
           ],
-          "createdTime": 1568368749846,
+          "createdTime": 1568884199063,
           "testId": "loginUserInputNotNullNotNullOutputTrue0031283edb7e0d812f2",
           "testedFunction": "java::com.diffblue.javademo.UserAccess.loginUser:(Ljava/lang/String;Ljava/lang/String;)Z",
           "sourceFilePath": "com/diffblue/javademo/UserAccess.java",
@@ -2747,7 +3318,7 @@
           "testName": "loginUserInputNotNullNotNullOutputTrue"
       }
   ],
-  "cursor": 1568368856458,
+  "cursor": 1568884356300,
   "status": {
       "status": "COMPLETED"
   }

--- a/tests/unit/analysis.ts
+++ b/tests/unit/analysis.ts
@@ -30,6 +30,7 @@ const sampleResult = {
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',
+  coveredLines: ['com.diffblue.javademo.TicTacToe.checkTicTacToePosition:1-2,4-5'],
 };
 const sampleBindingOptions = { allowUnauthorizedHttps: true };
 
@@ -73,7 +74,7 @@ describe('analysis', () => {
     });
 
     describe('run', () => {
-      const startResponse = { id: analysisId, phases: {}};
+      const startResponse = { id: analysisId, settings: {}};
       const responseStatus = { status: AnalysisStatus.CANCELED, progress: { completed: 10, total: 20 }};
       const resultsResponse = {
         status: responseStatus,
@@ -91,7 +92,7 @@ describe('analysis', () => {
           analysisId: analysisId,
           settings: settings,
           status: AnalysisStatus.CANCELED,
-          phases: {},
+          computedSettings: {},
           pollDelay: undefined,
           cursor: resultsResponse.cursor,
           progress: resultsResponse.status.progress,
@@ -116,7 +117,7 @@ describe('analysis', () => {
           analysisId: analysisId,
           settings: settings,
           status: AnalysisStatus.CANCELED,
-          phases: {},
+          computedSettings: {},
           pollDelay: undefined,
           cursor: resultsResponse.cursor,
           progress: resultsResponse.status.progress,
@@ -305,7 +306,7 @@ describe('analysis', () => {
     });
 
     describe('start', () => {
-      const startResponse = { id: analysisId, phases: {}};
+      const startResponse = { id: analysisId, settings: {}};
 
       it('Can start an analysis', sinonTest(async (sinon) => {
         const startAnalysis = sinon.stub(components, 'startAnalysis').resolves(startResponse);
@@ -316,7 +317,7 @@ describe('analysis', () => {
           analysisId: returnValue.id,
           settings: settings,
           status: AnalysisStatus.QUEUED,
-          phases: returnValue.phases,
+          computedSettings: returnValue.settings,
         };
         assert.deepStrictEqual(returnValue, startResponse);
         assert.calledOnceWith(startAnalysis, [apiUrl, files, {}, {}]);
@@ -333,7 +334,7 @@ describe('analysis', () => {
           analysisId: returnValue.id,
           settings: settings,
           status: AnalysisStatus.QUEUED,
-          phases: returnValue.phases,
+          computedSettings: returnValue.settings,
         };
         assert.calledOnceWith(startAnalysis, [apiUrl, allFiles, settings, {}]);
         assert.changedProperties(baseAnalysis, analysis, changes);
@@ -389,7 +390,7 @@ describe('analysis', () => {
     });
 
     describe('cancel', () => {
-      const startResponse = { id: analysisId, phases: {}};
+      const startResponse = { id: analysisId, settings: {}};
       const cancelStatus = { status: AnalysisStatus.STOPPING, progress: { completed: 10, total: 20 }};
       const cancelMessage = 'Analysis cancelled successfully';
       const cancelResponse = { message: cancelMessage, status: cancelStatus };
@@ -468,7 +469,7 @@ describe('analysis', () => {
     });
 
     describe('getStatus', () => {
-      const startResponse = { id: analysisId, phases: {}};
+      const startResponse = { id: analysisId, settings: {}};
       const statusResponse = { status: AnalysisStatus.COMPLETED, progress: { completed: 100, total: 100 }};
 
       it('Can get the status of an analysis', sinonTest(async (sinon) => {
@@ -555,7 +556,7 @@ describe('analysis', () => {
       it('Fails to get the status an analysis, if id not set', sinonTest(async (sinon) => {
         const analysis = new Analysis(apiUrl);
         const startAnalysis = sinon.stub(components, 'startAnalysis');
-        startAnalysis.resolves({ id: analysisId, phases: {}});
+        startAnalysis.resolves({ id: analysisId, settings: {}});
         await analysis.start(files, settings);
         analysis.analysisId = '';
         await assert.rejects(
@@ -568,7 +569,7 @@ describe('analysis', () => {
     });
 
     describe('getResults', () => {
-      const startResponse = { id: analysisId, phases: {}};
+      const startResponse = { id: analysisId, settings: {}};
       const responseStatus = { status: AnalysisStatus.RUNNING, progress: { completed: 10, total: 20 }};
       const resultsResponse = {
         status: responseStatus,

--- a/tests/unit/analysis.ts
+++ b/tests/unit/analysis.ts
@@ -27,6 +27,7 @@ const sampleResult = {
   imports: ['import'],
   staticImports: ['static import'],
   classAnnotations: ['class annotation'],
+  classRules: ['class rule'],
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',

--- a/tests/unit/bindings.ts
+++ b/tests/unit/bindings.ts
@@ -51,17 +51,17 @@ describe('api/bindings', () => {
     const startUrl = `${api}/analysis`;
     const settings = {
       ignoreDefaults: true,
-      phases: {},
+      settings: {},
     };
 
-    it('Starts an analysis then returns the id and phases', sinonTest(async (sinon) => {
+    it('Starts an analysis then returns the id and settings', sinonTest(async (sinon) => {
       const post = sinon.stub(dependencies.request, 'post');
 
-      post.withArgs(startUrl).resolves({ id: '1234-ABCD', phases: {}});
+      post.withArgs(startUrl).resolves({ id: '1234-ABCD', settings: {}});
       assert.notOtherwiseCalled(post, 'post');
 
       const actualResponse = await startAnalysis(api, { build: build });
-      const expectedResponse = { id: '1234-ABCD', phases: {}};
+      const expectedResponse = { id: '1234-ABCD', settings: {}};
 
       assert.deepStrictEqual(actualResponse, expectedResponse);
     }));
@@ -70,7 +70,7 @@ describe('api/bindings', () => {
       const append = sinon.stub(dependencies.FormData.prototype, 'append');
       const post = sinon.stub(dependencies.request, 'post');
 
-      post.withArgs(startUrl).resolves({ id: '1234-ABCD', phases: settings.phases });
+      post.withArgs(startUrl).resolves({ id: '1234-ABCD', settngs: settings });
       assert.notOtherwiseCalled(post, 'post');
 
       await startAnalysis(api, { build: build, baseBuild: baseBuild }, settings);
@@ -85,7 +85,7 @@ describe('api/bindings', () => {
       const append = sinon.stub(dependencies.FormData.prototype, 'append');
       const post = sinon.stub(dependencies.request, 'post');
 
-      post.withArgs(startUrl).resolves({ id: '1234-ABCD', phases: settings.phases });
+      post.withArgs(startUrl).resolves({ id: '1234-ABCD', settings: settings });
       assert.notOtherwiseCalled(post, 'post');
 
       await startAnalysis(api, { build: build, dependenciesBuild: dependenciesBuild }, settings);
@@ -100,7 +100,7 @@ describe('api/bindings', () => {
       const append = sinon.stub(dependencies.FormData.prototype, 'append');
       const post = sinon.stub(dependencies.request, 'post');
 
-      post.withArgs(startUrl).resolves({ id: '1234-ABCD', phases: settings.phases });
+      post.withArgs(startUrl).resolves({ id: '1234-ABCD', settings: settings });
       assert.notOtherwiseCalled(post, 'post');
 
       await startAnalysis(

--- a/tests/unit/combiner.ts
+++ b/tests/unit/combiner.ts
@@ -23,6 +23,7 @@ const sampleResult = {
   imports: ['import'],
   staticImports: ['static import'],
   classAnnotations: ['class annotation'],
+  classRules: ['class rule'],
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',
@@ -31,6 +32,7 @@ const sampleResult = {
 
 const sampleTestData = {
   classAnnotations: sampleResult.classAnnotations,
+  classRules: sampleResult.classRules,
   imports: sampleResult.imports,
   staticImports: sampleResult.staticImports,
   name: sampleResult.testName,

--- a/tests/unit/combiner.ts
+++ b/tests/unit/combiner.ts
@@ -26,6 +26,7 @@ const sampleResult = {
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',
+  coveredLines: ['com.diffblue.javademo.TicTacToe.checkTicTacToePosition:1-2,4-5'],
 };
 
 const sampleTestData = {
@@ -35,6 +36,8 @@ const sampleTestData = {
   name: sampleResult.testName,
   body: sampleResult.testBody,
   id: sampleResult.testId,
+  sourceFilePath: sampleResult.sourceFilePath,
+  coveredLines: sampleResult.coveredLines,
 };
 
 describe('combiner', () => {

--- a/tests/unit/writeTests.ts
+++ b/tests/unit/writeTests.ts
@@ -20,6 +20,7 @@ const sampleResult = {
   imports: ['import'],
   staticImports: ['static import'],
   classAnnotations: ['class annotation'],
+  classRules: ['class rules'],
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',

--- a/tests/unit/writeTests.ts
+++ b/tests/unit/writeTests.ts
@@ -23,6 +23,7 @@ const sampleResult = {
   tags: ['tag'],
   phaseGenerated: 'phase',
   createdTime: 'created',
+  coveredLines: ['com.diffblue.javademo.TicTacToe.checkTicTacToePosition:1-2,4-5'],
 };
 const otherResult = {
   ...sampleResult,

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@diffblue/java-combiner@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.7.tgz#77a5b98b4f35cd76a55cd46220cbf90fbd2c48f4"
-  integrity sha512-U1lbwy6VMB29+dWgixejXadzmSzF0wVAEJFjh+HBXwukUKB0PZJlRO4K13Qd7qsqC3hSbQm6rufwgtFWDSOKgw==
+"@diffblue/java-combiner@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.8.tgz#82599259430c90b6f10a42b11951a6c3edf301b6"
+  integrity sha512-CmeROi8+0HG7AwVxxu+gozmsAXJHHX/npr+Ser40R2kfWg8YZPDAPbAI0ffJyOjSeAmo5Dd14W8luYvmsXjJGg==
   dependencies:
     duplex-child-process "^1.0.0"
     lodash "4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,12 +124,13 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@diffblue/java-combiner@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.3.tgz#6276492406f6bb3e955c27c5893e50f66a573f56"
-  integrity sha512-/rd/2J9XQOuGlPQkbKui/ikVbpmCOY0W7SJHGnx5VsP3c02z00zSn1PKnN8eOlzY0VKOGuIhRWWekabxcR9S8Q==
+"@diffblue/java-combiner@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.6.tgz#77eb5dc0bb5601e855a252fb9ed70efb9cd4addb"
+  integrity sha512-c6l1f6blM5oiOJK7xEbf9bbm5LItmbd7O6MQIo/fgDzQYLRWorVkhLW70c4pX75KVnl44hysZ0GpMQtbXt+qnw==
   dependencies:
     duplex-child-process "^1.0.0"
+    lodash "4.17.15"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"
@@ -2310,6 +2311,11 @@ lodash@4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^4.17.11, lodash@latest:
   version "4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@diffblue/java-combiner@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.6.tgz#77eb5dc0bb5601e855a252fb9ed70efb9cd4addb"
-  integrity sha512-c6l1f6blM5oiOJK7xEbf9bbm5LItmbd7O6MQIo/fgDzQYLRWorVkhLW70c4pX75KVnl44hysZ0GpMQtbXt+qnw==
+"@diffblue/java-combiner@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@diffblue/java-combiner/-/java-combiner-0.1.7.tgz#77a5b98b4f35cd76a55cd46220cbf90fbd2c48f4"
+  integrity sha512-U1lbwy6VMB29+dWgixejXadzmSzF0wVAEJFjh+HBXwukUKB0PZJlRO4K13Qd7qsqC3hSbQm6rufwgtFWDSOKgw==
   dependencies:
     duplex-child-process "^1.0.0"
     lodash "4.17.15"


### PR DESCRIPTION
Bump java-combiner to latest version.
Add missing Test fields.
Update start analysis API response.
Update relevant types.
Update docs.
Update test writer integration tests to account for new test document fields and test sorting
Further updates for `classRules`


### Context/purpose

Once this is merged, a release can be made. This can then be used by the gitlab plugin.

CX team should also be informed that the client is up to date, re the Dashboard.

### Implementation details

<!-- How was this implemented? e.g. overall structure, complexities, caveats -->

### QA instructions

The client should now work correctly with the Platform Plugins API in its current state, including starting an analysis, fetching results and combining tests.

### Any unrelated changes?

<!-- Anything unrelated included in this PR (remove section if empty) -->

### PR Checklist

<!-- If this is strictly a documentation change you can replace the following checklist with "Documentation change only" -->

- [ ] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [ ] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [ ] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
