### PR TITLE
Update genTestClass arguments to match current signature [TG-9724]

### DIFF
--- a/src/combiner.ts
+++ b/src/combiner.ts
@@ -139,10 +139,10 @@ export function generateTestClass(results: AnalysisResult[]): string {
   const { testedFunction } = results[0];
   const className = parseClassNameFromFunctionName(testedFunction);
   const packageName = parsePackageNameFromFunctionName(testedFunction);
-  const testName = `${className}Test`;
+  const testClassName = `${className}Test`;
   const testData = prepareTestData(results);
   try {
-    return dependencies.genTestClass(testData, className, testName, packageName);
+    return dependencies.genTestClass(testData, testClassName, packageName);
   } catch (error) {
     throw new CombinerError(`Unexpected error generating test class:\n${error}`, CombinerErrorCode.GENERATE_ERROR);
   }

--- a/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedFirstTestClass.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 
 
 @RunWith(PowerMockRunner.class)
-public class UserAccess {
+public class UserAccessTest {
 
   @Rule
   public final Timeout globalTimeout = new Timeout(10000);

--- a/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMergedTestClass.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 
 
 @RunWith(PowerMockRunner.class)
-public class UserAccess {
+public class UserAccessTest {
 
   @Rule
   public final Timeout globalTimeout = new Timeout(10000);

--- a/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedMultiTestClass.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 
 
 @RunWith(PowerMockRunner.class)
-public class UserAccess {
+public class UserAccessTest {
 
   @Rule
   public final Timeout globalTimeout = new Timeout(10000);

--- a/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
+++ b/tests/integration/fixtures/combiner/ExpectedSingleTestClass.java
@@ -9,7 +9,7 @@ import org.junit.rules.Timeout;
 
 
 
-public class UserAccess {
+public class UserAccessTest {
 
   @Rule
   public final Timeout globalTimeout = new Timeout(10000);

--- a/tests/unit/combiner.ts
+++ b/tests/unit/combiner.ts
@@ -48,7 +48,7 @@ describe('combiner', () => {
       const genTestClass = sinon.stub(dependencies, 'genTestClass');
       genTestClass.returns(expectedTestClass);
       const testClass = generateTestClass([sampleResult]);
-      assert.calledOnceWith(genTestClass, [[sampleTestData], 'TicTacToe', 'TicTacToeTest', 'com.diffblue.javademo']);
+      assert.calledOnceWith(genTestClass, [[sampleTestData], 'TicTacToeTest', 'com.diffblue.javademo']);
       assert.strictEqual(testClass, expectedTestClass);
     }));
 
@@ -59,7 +59,7 @@ describe('combiner', () => {
       const testClass = generateTestClass([sampleResult, sampleResult]);
       assert.calledOnceWith(
         genTestClass,
-        [[sampleTestData, sampleTestData], 'TicTacToe', 'TicTacToeTest', 'com.diffblue.javademo'],
+        [[sampleTestData, sampleTestData], 'TicTacToeTest', 'com.diffblue.javademo'],
       );
       assert.strictEqual(testClass, expectedTestClass);
     }));


### PR DESCRIPTION
Fixes a bug where the test class name did not have a `Test` suffix.

### Context/purpose

Test classes need the correct name or they won't compile

### Implementation details

genTestClass was getting bad arguments based originally on the calls in Platform, which may have been correct at some point.

### QA instructions

Written test classes should now have a class name with the `Test` suffix.

### Any unrelated changes?

<!-- Anything unrelated included in this PR (remove section if empty) -->

### PR Checklist

<!-- If this is strictly a documentation change you can replace the following checklist with "Documentation change only" -->

- [x] I have given the PR a meaningful title which can be understood out of context (used in the changelog)
- [x] I have read through my code and fixed the indentation, followed naming conventions and removed leftover debugging
- [x] I have added the Jira ticket number(s) to the title with the format "Description of the feature [TG-123, TG-456]" and have copied the QA instructions to the Jira ticket (if one exists)
